### PR TITLE
feat: 상품 추가 api 구현 및 필요한 기반 클래스들 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ myDatabaseInfo.properties
 
 ### log ###
 *.log
+*.gz

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,14 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    // queryDSL
+    implementation 'com.querydsl:querydsl-jpa:5.0.0'
+    annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jpa'
+    annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+    annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'

--- a/src/main/java/com/zerobase/everycampingbackend/common/exception/ErrorCode.java
+++ b/src/main/java/com/zerobase/everycampingbackend/common/exception/ErrorCode.java
@@ -10,7 +10,13 @@ import lombok.RequiredArgsConstructor;
 public enum ErrorCode {
 
   UNKNOWN_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 예외가 발생했습니다."),
-  ORDER_AMOUNT_UNDER_1000(HttpStatus.BAD_REQUEST, "1000원 이하로는 주문할 수 없습니다.");
+  ORDER_AMOUNT_UNDER_1000(HttpStatus.BAD_REQUEST, "1000원 이하로는 주문할 수 없습니다."),
+  PRODUCT_NOT_FOUND(HttpStatus.BAD_REQUEST, "상품을 찾을 수 없습니다."),
+  PRODUCT_SELLER_NOT_MATCHED(HttpStatus.BAD_REQUEST, "상품 수정/삭제 권한이 없습니다."),
+  PRODUCT_NOT_ENOUGH_STOCK(HttpStatus.BAD_REQUEST, "상품의 재고가 부족합니다."),
+  PRODUCT_NOT_ON_SALE(HttpStatus.BAD_REQUEST, "상품이 판매 중이 아닙니다.")
+
+  ;
 
   private final HttpStatus httpStatus;
   private final String detail;

--- a/src/main/java/com/zerobase/everycampingbackend/product/config/QueryDslConfig.java
+++ b/src/main/java/com/zerobase/everycampingbackend/product/config/QueryDslConfig.java
@@ -1,0 +1,20 @@
+package com.zerobase.everycampingbackend.product.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(){
+        return new JPAQueryFactory(entityManager);
+    }
+
+}

--- a/src/main/java/com/zerobase/everycampingbackend/product/controller/ProductManageController.java
+++ b/src/main/java/com/zerobase/everycampingbackend/product/controller/ProductManageController.java
@@ -1,0 +1,25 @@
+package com.zerobase.everycampingbackend.product.controller;
+
+import com.zerobase.everycampingbackend.product.domain.form.ProductManageForm;
+import com.zerobase.everycampingbackend.product.service.ProductManageService;
+import javax.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/products/manage")
+public class ProductManageController {
+
+    private final ProductManageService productManageService;
+
+    @PostMapping
+    public ResponseEntity<Boolean> addProduct(@RequestBody @Valid ProductManageForm form) {
+        productManageService.addProduct(form);
+        return ResponseEntity.ok(true);
+    }
+}

--- a/src/main/java/com/zerobase/everycampingbackend/product/domain/dto/ProductDetailDto.java
+++ b/src/main/java/com/zerobase/everycampingbackend/product/domain/dto/ProductDetailDto.java
@@ -1,0 +1,55 @@
+package com.zerobase.everycampingbackend.product.domain.dto;
+
+import com.zerobase.everycampingbackend.product.domain.entity.Product;
+import com.zerobase.everycampingbackend.product.type.ProductCategory;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ProductDetailDto {
+
+    private Long id;
+    private String sellerName;
+    private ProductCategory category;
+    private String name;
+    private String description;
+    private int stock;
+    private int price;
+    private String imagePath;
+    private List<String> tags;
+    private boolean onSale;
+    private int reviewCount;
+    private double avgScore;
+
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+
+    public static ProductDetailDto from(Product product) {
+        return ProductDetailDto.builder()
+            .id(product.getId())
+            // .sellerName(product.getSeller().getName())
+            .category(product.getCategory())
+            .name(product.getName())
+            .description(product.getDescription())
+            .stock(product.getStock())
+            .price(product.getPrice())
+            .imagePath(product.getDetailImagePath())
+            .tags(product.getTags())
+            .onSale(product.isOnSale())
+            .reviewCount(product.getReviewCount())
+            .avgScore(product.getReviewCount() == 0 ? 0
+                : product.getTotalScore() / (double) product.getReviewCount())
+            .createdAt(product.getCreatedAt())
+            .modifiedAt(product.getModifiedAt())
+            .build();
+    }
+}

--- a/src/main/java/com/zerobase/everycampingbackend/product/domain/dto/ProductDto.java
+++ b/src/main/java/com/zerobase/everycampingbackend/product/domain/dto/ProductDto.java
@@ -1,0 +1,43 @@
+package com.zerobase.everycampingbackend.product.domain.dto;
+
+import com.zerobase.everycampingbackend.product.domain.entity.Product;
+import com.zerobase.everycampingbackend.product.type.ProductCategory;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ProductDto {
+
+    private Long id;
+    private ProductCategory category;
+    private String name;
+    private int price;
+    private String imagePath;
+    private int reviewCount;
+    private double avgScore;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+
+    public static ProductDto from(Product product) {
+        return ProductDto.builder()
+            .id(product.getId())
+            .category(product.getCategory())
+            .name(product.getName())
+            .price(product.getPrice())
+            .imagePath(product.getImagePath())
+            .reviewCount(product.getReviewCount())
+            .avgScore(product.getReviewCount() == 0 ? 0
+                : product.getTotalScore() / (double) product.getReviewCount())
+            .createdAt(product.getCreatedAt())
+            .modifiedAt(product.getModifiedAt())
+            .build();
+    }
+}

--- a/src/main/java/com/zerobase/everycampingbackend/product/domain/entity/Product.java
+++ b/src/main/java/com/zerobase/everycampingbackend/product/domain/entity/Product.java
@@ -1,0 +1,45 @@
+package com.zerobase.everycampingbackend.product.domain.entity;
+
+import com.zerobase.everycampingbackend.common.BaseEntity;
+import com.zerobase.everycampingbackend.product.type.ProductCategory;
+import java.util.List;
+import javax.persistence.ElementCollection;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+public class Product extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // private Seller seller;
+
+    @Enumerated(EnumType.STRING)
+    private ProductCategory category;
+    private String name;
+    private String description;
+    private int stock;
+    private int price;
+    private String imagePath;
+    private String detailImagePath;
+    private boolean onSale;
+    @ElementCollection
+    private List<String> tags;
+    private int reviewCount;
+    private int totalScore;
+}

--- a/src/main/java/com/zerobase/everycampingbackend/product/domain/form/ProductManageForm.java
+++ b/src/main/java/com/zerobase/everycampingbackend/product/domain/form/ProductManageForm.java
@@ -1,0 +1,32 @@
+package com.zerobase.everycampingbackend.product.domain.form;
+
+import com.zerobase.everycampingbackend.product.type.ProductCategory;
+import java.util.List;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ProductManageForm {
+
+    @NotNull
+    private ProductCategory category;
+    @NotBlank
+    private String name;
+    @NotNull
+    private Integer price;
+    @NotNull
+    private Boolean onSale;
+
+    private String description;
+    private Integer stock;
+    private String imagePath;
+    private String detailImagePath;
+    private List<String> tags;
+}

--- a/src/main/java/com/zerobase/everycampingbackend/product/repository/ProductRepository.java
+++ b/src/main/java/com/zerobase/everycampingbackend/product/repository/ProductRepository.java
@@ -1,0 +1,11 @@
+package com.zerobase.everycampingbackend.product.repository;
+
+import com.zerobase.everycampingbackend.product.domain.entity.Product;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ProductRepository extends JpaRepository<Product, Long>, ProductRepositoryCustom {
+
+
+}

--- a/src/main/java/com/zerobase/everycampingbackend/product/repository/ProductRepositoryCustom.java
+++ b/src/main/java/com/zerobase/everycampingbackend/product/repository/ProductRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.zerobase.everycampingbackend.product.repository;
+
+import com.zerobase.everycampingbackend.product.domain.dto.ProductDto;
+import com.zerobase.everycampingbackend.product.domain.form.ProductSearchForm;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface ProductRepositoryCustom {
+    Page<ProductDto> searchAll(ProductSearchForm form, Pageable pageable);
+}

--- a/src/main/java/com/zerobase/everycampingbackend/product/service/ProductManageService.java
+++ b/src/main/java/com/zerobase/everycampingbackend/product/service/ProductManageService.java
@@ -1,0 +1,39 @@
+package com.zerobase.everycampingbackend.product.service;
+
+import com.zerobase.everycampingbackend.product.domain.entity.Product;
+import com.zerobase.everycampingbackend.product.domain.form.ProductManageForm;
+import com.zerobase.everycampingbackend.product.repository.ProductRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ProductManageService {
+
+    private final ProductRepository productRepository;
+
+    @Transactional
+    public void addProduct(ProductManageForm form) {
+        // 토큰 통해 받아오는 객체에서 판매자 추출
+
+        log.info("상품명 (" + form.getName() + ") 추가 시도");
+
+        productRepository.save(Product.builder()
+            .name(form.getName())
+            .category(form.getCategory())
+            .price(form.getPrice())
+            .onSale(form.getOnSale())
+            .stock(form.getStock())
+            .description(form.getDescription())
+            .imagePath(form.getImagePath())
+            .detailImagePath(form.getDetailImagePath())
+            .tags(form.getTags())
+            .build());
+
+        log.info("상품명 (" + form.getName() + ") 추가 완료");
+    }
+}

--- a/src/main/java/com/zerobase/everycampingbackend/product/type/ProductCategory.java
+++ b/src/main/java/com/zerobase/everycampingbackend/product/type/ProductCategory.java
@@ -1,0 +1,8 @@
+package com.zerobase.everycampingbackend.product.type;
+
+public enum ProductCategory {
+    TENT,
+    TABLE,
+    CHAIR,
+    MAT
+}

--- a/src/test/java/com/zerobase/everycampingbackend/product/service/ProductManageServiceTest.java
+++ b/src/test/java/com/zerobase/everycampingbackend/product/service/ProductManageServiceTest.java
@@ -1,0 +1,68 @@
+package com.zerobase.everycampingbackend.product.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.verify;
+
+import com.zerobase.everycampingbackend.product.domain.entity.Product;
+import com.zerobase.everycampingbackend.product.domain.form.ProductManageForm;
+import com.zerobase.everycampingbackend.product.repository.ProductRepository;
+import com.zerobase.everycampingbackend.product.type.ProductCategory;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@TestPropertySource(locations = "classpath:application-test.properties")
+@TestInstance(TestInstance.Lifecycle.PER_METHOD)
+@Transactional
+class ProductManageServiceTest {
+    @Mock
+    private ProductRepository productRepository;
+
+    @InjectMocks
+    private ProductManageService productManageService;
+
+    private ProductManageForm form = ProductManageForm.builder()
+        .category(ProductCategory.TENT)
+        .name("텐트입니다")
+        .price(100000)
+        .onSale(true)
+        .description("아주 좋은 텐트입니다")
+        .stock(10)
+        .imagePath("이미지경로")
+        .detailImagePath("상세이미지경로")
+        .tags(List.of("따뜻함", "안락", "고퀄"))
+        .build();
+
+    @Test
+    @DisplayName("상품 추가 성공")
+    void success_addProduct(){
+        // given
+        ArgumentCaptor<Product> captor = ArgumentCaptor.forClass(Product.class);
+
+        // when
+        productManageService.addProduct(form);
+
+        // then
+        verify(productRepository).save(captor.capture());
+        Product captorValue = captor.getValue();
+        assertEquals(form.getName(), captorValue.getName());
+        assertEquals(form.getPrice(), captorValue.getPrice());
+        assertEquals(form.getOnSale(), captorValue.isOnSale());
+        assertEquals(form.getDescription(), captorValue.getDescription());
+        assertEquals(form.getStock(), captorValue.getStock());
+        assertEquals(form.getImagePath(), captorValue.getImagePath());
+        assertEquals(form.getDetailImagePath(), captorValue.getDetailImagePath());
+        for(String tag : form.getTags()){
+            assertTrue(captorValue.getTags().contains(tag));
+        }
+    }
+}


### PR DESCRIPTION
### Background
---
상품 등록은 판매자만 가능하기에 추후 token을 받을 필요가 있다.
issue로 달아 놓을 예정이다.

### Change
---
Entity, Dto, form 등 필요한 domain을 추가하였다.
의존성에 Validation, QueryDsl 추가하였다.
상품 관련 ErrorCode를 추가하였다.
gitignore에 gz 확장자 파일을 추가하였다.

### Test
---
Mokito를 사용한 테스트 작성 및 확인 완료.

### Analatics
---
form을 그대로 service 단으로 내려 코드의 간결성을 높인 것 같다.

### Discuss
---
상품 파트 첫 pr이라 조금 많습니다.
QueryDsl 같은 것은 조회 부분 추가 할 때 같이 추가했어야 했나 하는 생각도 듭니다.