### PR TITLE
판매자용 상품 조회 & 삭제 기능 추가

### DIFF
--- a/src/main/java/com/zerobase/everycampingbackend/product/controller/ProductManageController.java
+++ b/src/main/java/com/zerobase/everycampingbackend/product/controller/ProductManageController.java
@@ -1,10 +1,15 @@
 package com.zerobase.everycampingbackend.product.controller;
 
+import com.zerobase.everycampingbackend.product.domain.dto.ProductDetailDto;
+import com.zerobase.everycampingbackend.product.domain.dto.ProductDto;
 import com.zerobase.everycampingbackend.product.domain.form.ProductManageForm;
 import com.zerobase.everycampingbackend.product.service.ProductManageService;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -30,5 +35,15 @@ public class ProductManageController {
         @RequestBody @Valid ProductManageForm form) {
         productManageService.updateProduct(productId, form);
         return ResponseEntity.ok(true);
+    }
+
+    @GetMapping("/{productId}")
+    public ResponseEntity<ProductDetailDto> getProductDetail(@PathVariable Long productId){
+        return ResponseEntity.ok(productManageService.getProductDetail(productId));
+    }
+
+    @GetMapping
+    public ResponseEntity<Page<ProductDto>> getProductPage(Pageable pageable){
+        return ResponseEntity.ok(productManageService.getProductPage(pageable));
     }
 }

--- a/src/main/java/com/zerobase/everycampingbackend/product/controller/ProductManageController.java
+++ b/src/main/java/com/zerobase/everycampingbackend/product/controller/ProductManageController.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -34,6 +35,12 @@ public class ProductManageController {
     public ResponseEntity<Boolean> updateProduct(@PathVariable Long productId,
         @RequestBody @Valid ProductManageForm form) {
         productManageService.updateProduct(productId, form);
+        return ResponseEntity.ok(true);
+    }
+
+    @DeleteMapping("/{productId}")
+    public ResponseEntity<Boolean> deleteProduct(@PathVariable Long productId) {
+        productManageService.deleteProduct(productId);
         return ResponseEntity.ok(true);
     }
 

--- a/src/main/java/com/zerobase/everycampingbackend/product/domain/entity/Product.java
+++ b/src/main/java/com/zerobase/everycampingbackend/product/domain/entity/Product.java
@@ -1,6 +1,7 @@
 package com.zerobase.everycampingbackend.product.domain.entity;
 
 import com.zerobase.everycampingbackend.common.BaseEntity;
+import com.zerobase.everycampingbackend.product.domain.form.ProductManageForm;
 import com.zerobase.everycampingbackend.product.type.ProductCategory;
 import java.util.List;
 import javax.persistence.ElementCollection;
@@ -42,4 +43,30 @@ public class Product extends BaseEntity {
     private List<String> tags;
     private int reviewCount;
     private int totalScore;
+
+    public static Product from(ProductManageForm form){
+        return Product.builder()
+            .name(form.getName())
+            .category(form.getCategory())
+            .price(form.getPrice())
+            .onSale(form.getOnSale())
+            .stock(form.getStock())
+            .description(form.getDescription())
+            .imagePath(form.getImagePath())
+            .detailImagePath(form.getDetailImagePath())
+            .tags(form.getTags())
+            .build();
+    }
+
+    public void setFrom(ProductManageForm form){
+        setName(form.getName());
+        setCategory(form.getCategory());
+        setPrice(form.getPrice());
+        setStock(form.getStock());
+        setOnSale(form.getOnSale());
+        setDescription(form.getDescription());
+        setImagePath(form.getImagePath());
+        setDetailImagePath(form.getDetailImagePath());
+        setTags(form.getTags());
+    }
 }

--- a/src/main/java/com/zerobase/everycampingbackend/product/domain/form/ProductSearchForm.java
+++ b/src/main/java/com/zerobase/everycampingbackend/product/domain/form/ProductSearchForm.java
@@ -1,0 +1,19 @@
+package com.zerobase.everycampingbackend.product.domain.form;
+
+import com.zerobase.everycampingbackend.product.type.ProductCategory;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ProductSearchForm {
+    private String name;
+    private String sellerName;
+    private ProductCategory category;
+    private List<String> tags;
+}

--- a/src/main/java/com/zerobase/everycampingbackend/product/service/ProductManageService.java
+++ b/src/main/java/com/zerobase/everycampingbackend/product/service/ProductManageService.java
@@ -2,11 +2,15 @@ package com.zerobase.everycampingbackend.product.service;
 
 import com.zerobase.everycampingbackend.common.exception.CustomException;
 import com.zerobase.everycampingbackend.common.exception.ErrorCode;
+import com.zerobase.everycampingbackend.product.domain.dto.ProductDetailDto;
+import com.zerobase.everycampingbackend.product.domain.dto.ProductDto;
 import com.zerobase.everycampingbackend.product.domain.entity.Product;
 import com.zerobase.everycampingbackend.product.domain.form.ProductManageForm;
 import com.zerobase.everycampingbackend.product.repository.ProductRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,17 +28,7 @@ public class ProductManageService {
 
         log.info("상품명 (" + form.getName() + ") 추가 시도");
 
-        productRepository.save(Product.builder()
-            .name(form.getName())
-            .category(form.getCategory())
-            .price(form.getPrice())
-            .onSale(form.getOnSale())
-            .stock(form.getStock())
-            .description(form.getDescription())
-            .imagePath(form.getImagePath())
-            .detailImagePath(form.getDetailImagePath())
-            .tags(form.getTags())
-            .build());
+        productRepository.save(Product.from(form));
 
         log.info("상품명 (" + form.getName() + ") 추가 완료");
     }
@@ -47,15 +41,7 @@ public class ProductManageService {
 
         log.info("상품명 (" + form.getName() + ") 수정 시도");
 
-        product.setName(form.getName());
-        product.setCategory(form.getCategory());
-        product.setPrice(form.getPrice());
-        product.setStock(form.getStock());
-        product.setOnSale(form.getOnSale());
-        product.setDescription(form.getDescription());
-        product.setImagePath(form.getImagePath());
-        product.setDetailImagePath(form.getDetailImagePath());
-        product.setTags(form.getTags());
+        product.setFrom(form);
 
         productRepository.save(product);
 
@@ -65,5 +51,20 @@ public class ProductManageService {
     private Product getProductById(long productId) {
         return productRepository.findById(productId)
             .orElseThrow(() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
+    }
+
+    public ProductDetailDto getProductDetail(Long productId) {
+        Product product = getProductById(productId);
+
+        // 토큰 통해 받아오는 유저객체와 product 통해 받아오는 유저객체 id 일치 여부 확인
+
+        log.info("상품명 (" + product.getName() + ") 판매자용 조회");
+
+        return ProductDetailDto.from(product);
+    }
+
+    public Page<ProductDto> getProductPage(Pageable pageable) {
+        return productRepository.findAll(pageable)
+            .map(ProductDto::from);
     }
 }

--- a/src/main/java/com/zerobase/everycampingbackend/product/service/ProductManageService.java
+++ b/src/main/java/com/zerobase/everycampingbackend/product/service/ProductManageService.java
@@ -53,6 +53,19 @@ public class ProductManageService {
             .orElseThrow(() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
     }
 
+    @Transactional
+    public void deleteProduct(long productId) {
+        Product product = getProductById(productId);
+
+        // 토큰 통해 받아오는 유저객체와 product 통해 받아오는 유저객체 id 일치 여부 확인
+
+        log.info("상품명 (" + product.getName() + ") 삭제 시도");
+
+        productRepository.delete(product);
+
+        log.info("상품명 (" + product.getName() + ") 삭제 완료");
+    }
+
     public ProductDetailDto getProductDetail(Long productId) {
         Product product = getProductById(productId);
 


### PR DESCRIPTION
Background
---
판매자 전용의 상품 조회 & 삭제 기능이 필요하다.

Change
---
Product Entity 내에 from 메소드 생성해 서비스 단에서 form을 이용해 Entity 관리하는 부분 시각적 간략화.
판매자용 상품 목록 조회 기능 추가
판매자용 상품 상세 조회 기능 추가
판매자용 상품 삭제 기능 추가

Test
---
[x] 로직 테스트 완료

Analatics
---
차후 판매자 클래스가 추가되면 연관관계 매핑이 생길 것이다.
삭제 시에 사이드 이펙트가 생기지는 않을 지 확인이 필요하다.

Discuss
---
