### PR TITLE
CUSTOMER_PRODUCT_VIEW

### DIFF
--- a/src/main/java/com/zerobase/everycampingbackend/product/controller/ProductController.java
+++ b/src/main/java/com/zerobase/everycampingbackend/product/controller/ProductController.java
@@ -1,0 +1,33 @@
+package com.zerobase.everycampingbackend.product.controller;
+
+import com.zerobase.everycampingbackend.product.domain.dto.ProductDto;
+import com.zerobase.everycampingbackend.product.domain.form.ProductSearchForm;
+import com.zerobase.everycampingbackend.product.domain.dto.ProductDetailDto;
+import com.zerobase.everycampingbackend.product.service.ProductService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/products")
+public class ProductController {
+
+    private final ProductService productService;
+
+    @GetMapping
+    public ResponseEntity<Page<ProductDto>> searchProduct(@ModelAttribute ProductSearchForm form, Pageable pageable){
+        return ResponseEntity.ok(productService.getProducts(form, pageable));
+    }
+
+    @GetMapping("/{productId}")
+    public ResponseEntity<ProductDetailDto> getProductDetail(@PathVariable Long productId){
+        return ResponseEntity.ok(productService.getProductDetail(productId));
+    }
+}

--- a/src/main/java/com/zerobase/everycampingbackend/product/controller/ProductManageController.java
+++ b/src/main/java/com/zerobase/everycampingbackend/product/controller/ProductManageController.java
@@ -20,7 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/products/manage")
+@RequestMapping("/manage/products")
 public class ProductManageController {
 
     private final ProductManageService productManageService;

--- a/src/main/java/com/zerobase/everycampingbackend/product/domain/form/ProductSearchForm.java
+++ b/src/main/java/com/zerobase/everycampingbackend/product/domain/form/ProductSearchForm.java
@@ -6,8 +6,10 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder

--- a/src/main/java/com/zerobase/everycampingbackend/product/repository/ProductRepository.java
+++ b/src/main/java/com/zerobase/everycampingbackend/product/repository/ProductRepository.java
@@ -1,11 +1,12 @@
 package com.zerobase.everycampingbackend.product.repository;
 
 import com.zerobase.everycampingbackend.product.domain.entity.Product;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ProductRepository extends JpaRepository<Product, Long>, ProductRepositoryCustom {
-
-
+    Page<Product> findAll(Pageable pageable);
 }

--- a/src/main/java/com/zerobase/everycampingbackend/product/repository/ProductRepositoryImpl.java
+++ b/src/main/java/com/zerobase/everycampingbackend/product/repository/ProductRepositoryImpl.java
@@ -1,0 +1,77 @@
+package com.zerobase.everycampingbackend.product.repository;
+
+import static com.zerobase.everycampingbackend.product.domain.entity.QProduct.product;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.util.StringUtils;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.zerobase.everycampingbackend.product.domain.dto.ProductDto;
+import com.zerobase.everycampingbackend.product.domain.entity.Product;
+import com.zerobase.everycampingbackend.product.domain.form.ProductSearchForm;
+import com.zerobase.everycampingbackend.product.type.ProductCategory;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.ObjectUtils;
+
+@Repository
+@RequiredArgsConstructor
+public class ProductRepositoryImpl implements ProductRepositoryCustom{
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<ProductDto> searchAll(ProductSearchForm form, Pageable pageable) {
+        List<Product> products =  queryFactory.selectFrom(product)
+            .where(
+                likeName(form.getName()),
+//                eqSellerName(form.getSellerName()),
+                eqCategory(form.getCategory()),
+                containTags(form.getTags())
+            )
+            .orderBy(product.id.desc())
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch();
+
+        return new PageImpl<>(products.stream().map(ProductDto::from).collect(Collectors.toList()));
+    }
+
+    private BooleanBuilder containTags(List<String> tags) {
+        if(ObjectUtils.isEmpty(tags)) {
+            return null;
+        }
+        BooleanBuilder booleanBuilder = new BooleanBuilder();
+        for (String tag : tags){
+            booleanBuilder.and(product.tags.contains(tag));
+        }
+        return booleanBuilder;
+    }
+
+    private BooleanExpression eqCategory(ProductCategory category) {
+        if(ObjectUtils.isEmpty(category)) {
+            return null;
+        }
+        return product.category.eq(category);
+    }
+
+//    private BooleanExpression eqSellerName(String sellerName) {
+//        if(StringUtils.isNullOrEmpty(sellerName)) {
+//            return null;
+//        }
+//
+//        return product.seller.eq(sellerName);
+//    }
+
+    private BooleanExpression likeName(String name) {
+        if(StringUtils.isNullOrEmpty(name)) {
+            return null;
+        }
+
+        return product.name.like("%" + name + "%");
+    }
+}

--- a/src/main/java/com/zerobase/everycampingbackend/product/service/ProductService.java
+++ b/src/main/java/com/zerobase/everycampingbackend/product/service/ProductService.java
@@ -1,0 +1,33 @@
+package com.zerobase.everycampingbackend.product.service;
+
+import com.zerobase.everycampingbackend.common.exception.CustomException;
+import com.zerobase.everycampingbackend.common.exception.ErrorCode;
+import com.zerobase.everycampingbackend.product.domain.dto.ProductDetailDto;
+import com.zerobase.everycampingbackend.product.domain.dto.ProductDto;
+import com.zerobase.everycampingbackend.product.domain.form.ProductSearchForm;
+import com.zerobase.everycampingbackend.product.repository.ProductRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ProductService {
+    private final ProductRepository productRepository;
+
+    public ProductDetailDto getProductDetail(Long productId) {
+        return ProductDetailDto.from(productRepository.findById(productId)
+            .orElseThrow(() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND)));
+    }
+
+    public Page<ProductDto> getProducts(ProductSearchForm form, Pageable pageable){
+        long start = System.currentTimeMillis();
+        Page<ProductDto> result = productRepository.searchAll(form, pageable);
+        long end = System.currentTimeMillis();
+        log.info("검색 수행 : " + (end - start) + "ms 소요");
+        return result;
+    }
+}

--- a/src/main/java/com/zerobase/everycampingbackend/product/service/ProductService.java
+++ b/src/main/java/com/zerobase/everycampingbackend/product/service/ProductService.java
@@ -11,10 +11,12 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class ProductService {
     private final ProductRepository productRepository;
 

--- a/src/test/java/com/zerobase/everycampingbackend/product/service/ProductServiceTest.java
+++ b/src/test/java/com/zerobase/everycampingbackend/product/service/ProductServiceTest.java
@@ -1,0 +1,165 @@
+package com.zerobase.everycampingbackend.product.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.zerobase.everycampingbackend.common.exception.CustomException;
+import com.zerobase.everycampingbackend.common.exception.ErrorCode;
+import com.zerobase.everycampingbackend.product.domain.dto.ProductDetailDto;
+import com.zerobase.everycampingbackend.product.domain.dto.ProductDto;
+import com.zerobase.everycampingbackend.product.domain.entity.Product;
+import com.zerobase.everycampingbackend.product.domain.form.ProductSearchForm;
+import com.zerobase.everycampingbackend.product.repository.ProductRepository;
+import com.zerobase.everycampingbackend.product.type.ProductCategory;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@TestPropertySource(locations = "classpath:application-test.properties")
+@TestInstance(TestInstance.Lifecycle.PER_METHOD)
+@Transactional
+class ProductServiceTest {
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Autowired
+    private ProductService productService;
+
+    Product product1 = Product.builder()
+        .name("상품1")
+        .category(ProductCategory.TENT)
+        .tags(List.of("따뜻", "단아"))
+        .build();
+    Product product2 = Product.builder()
+        .name("상품2")
+        .category(ProductCategory.MAT)
+        .tags(List.of("따뜻", "우리집"))
+        .build();
+
+    Product product3 = Product.builder()
+        .name("상품3")
+        .category(ProductCategory.TABLE)
+        .tags(List.of("쿨", "우리집"))
+        .build();
+
+    Product product4 = Product.builder()
+        .name("텐트임")
+        .category(ProductCategory.TENT)
+        .tags(List.of("럭셔리"))
+        .build();
+
+    ProductSearchForm form = ProductSearchForm.builder().build();
+
+    @BeforeEach
+    void setUp() {
+        productRepository.save(product1);
+        productRepository.save(product2);
+        productRepository.save(product3);
+        productRepository.save(product4);
+    }
+
+    @Test
+    @DisplayName("고객 상품 상세 조회 성공")
+    void success_getProductDetail(){
+        // given
+        // when
+        ProductDetailDto result = productService.getProductDetail(product1.getId());
+
+        // then
+        assertEquals(product1.getName(), result.getName());
+        assertEquals(product1.getCategory(), result.getCategory());
+        for(int i = 0; i < product1.getTags().size(); i++){
+            assertEquals(product1.getTags().get(i), result.getTags().get(i));
+        }
+    }
+
+    @Test
+    @DisplayName("고객 상품 상세 조회 실패 - 해당 상품 없음")
+    void fail_getProductDetail_productNotFound(){
+        // given
+        // when
+        CustomException exception = assertThrows(CustomException.class, () ->
+            productService.getProductDetail(100L));
+
+        // then
+        assertEquals(ErrorCode.PRODUCT_NOT_FOUND, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("고객 상품 검색 성공 - 상품 이름")
+    void success_getProducts_byProductName(){
+        // given
+        PageRequest pageRequest = PageRequest.of(0, 5);
+        form.setName("상품");
+        // when
+        Page<ProductDto> result = productService.getProducts(form, pageRequest);
+
+        // then
+        assertEquals(3, result.getSize());
+        assertEquals(product3.getName(), result.getContent().get(0).getName());
+        assertEquals(product2.getName(), result.getContent().get(1).getName());
+        assertEquals(product1.getName(), result.getContent().get(2).getName());
+    }
+
+    @Test
+    @DisplayName("고객 상품 검색 성공 - 상품 카테고리")
+    void success_getProducts_byProductCategory(){
+        // given
+        PageRequest pageRequest = PageRequest.of(0, 5);
+        form.setCategory(ProductCategory.TENT);
+        // when
+        Page<ProductDto> result = productService.getProducts(form, pageRequest);
+
+        // then
+        assertEquals(2, result.getSize());
+        assertEquals(product4.getName(), result.getContent().get(0).getName());
+        assertEquals(product1.getName(), result.getContent().get(1).getName());
+    }
+
+    @Test
+    @DisplayName("고객 상품 검색 성공 - 상품 태그")
+    void success_getProducts_byProductTags(){
+        // given
+        PageRequest pageRequest = PageRequest.of(0, 5);
+
+        // when
+        form.setTags(List.of("우리집"));
+        Page<ProductDto> result = productService.getProducts(form, pageRequest);
+
+        form.setTags(List.of("럭셔리"));
+        Page<ProductDto> result2 = productService.getProducts(form, pageRequest);
+
+        // then
+        assertEquals(2, result.getSize());
+        assertEquals(product3.getName(), result.getContent().get(0).getName());
+        assertEquals(product2.getName(), result.getContent().get(1).getName());
+
+        assertEquals(1, result2.getSize());
+        assertEquals(product4.getName(), result2.getContent().get(0).getName());
+    }
+
+    @Test
+    @DisplayName("고객 상품 검색 성공 - 상품 이름 + 카테고리")
+    void success_getProducts_byProductNameAndCategory(){
+        // given
+        PageRequest pageRequest = PageRequest.of(0, 5);
+        form.setName("상품");
+        form.setCategory(ProductCategory.TENT);
+        // when
+        Page<ProductDto> result = productService.getProducts(form, pageRequest);
+
+        // then
+        assertEquals(1, result.getSize());
+        assertEquals(product1.getName(), result.getContent().get(0).getName());
+    }
+}


### PR DESCRIPTION
### Background
---
우선 기본 구현을 하고 리팩토링을 통해 성능 향상을 노리는 전략을 쓰기로 하였다.
검색에는 ES를 활용할 예정이나, 빠른 구현을 위해 querydsl을 사용하였다.

### Change
---
고객용 검색 기능 추가 (QueryDsl)
판매자용 상품 관리 api 경로 변경: products/manage -> /manage/products

### Test
---
JUnit을 이용해 서비스단에 대한 유닛 테스트 완료

### Analatics
---
DB에 검색에 적합한 인덱싱을 하지 않았기에, 레코드 개수가 많아질 수록 검색 성능이 저하될 우려가 있다.

### Discuss
---
테스트용으로 입력해 둘 객체를 생성할 때, 하드코딩으로 생성을 했는데, 크게 중요하지 않은 부분임에도 생각보다 면적을 잡아먹습니다. 또한 테스트 클래스마다 비슷한 객체를 반복해 선언하고 생성해 낭비가 있는 것도 같습니다. 보다 나은 방법이 있으면 조언 부탁드립니다.