### PR TITLE
MOVE-REPOSITORY-PACKAGE-LOCATION

### DIFF
--- a/src/main/java/com/zerobase/everycampingbackend/product/domain/repository/ProductRepository.java
+++ b/src/main/java/com/zerobase/everycampingbackend/product/domain/repository/ProductRepository.java
@@ -1,4 +1,4 @@
-package com.zerobase.everycampingbackend.product.repository;
+package com.zerobase.everycampingbackend.product.domain.repository;
 
 import com.zerobase.everycampingbackend.product.domain.entity.Product;
 import org.springframework.data.domain.Page;

--- a/src/main/java/com/zerobase/everycampingbackend/product/domain/repository/ProductRepositoryCustom.java
+++ b/src/main/java/com/zerobase/everycampingbackend/product/domain/repository/ProductRepositoryCustom.java
@@ -1,4 +1,4 @@
-package com.zerobase.everycampingbackend.product.repository;
+package com.zerobase.everycampingbackend.product.domain.repository;
 
 import com.zerobase.everycampingbackend.product.domain.dto.ProductDto;
 import com.zerobase.everycampingbackend.product.domain.form.ProductSearchForm;

--- a/src/main/java/com/zerobase/everycampingbackend/product/domain/repository/ProductRepositoryImpl.java
+++ b/src/main/java/com/zerobase/everycampingbackend/product/domain/repository/ProductRepositoryImpl.java
@@ -1,4 +1,4 @@
-package com.zerobase.everycampingbackend.product.repository;
+package com.zerobase.everycampingbackend.product.domain.repository;
 
 import static com.zerobase.everycampingbackend.product.domain.entity.QProduct.product;
 

--- a/src/main/java/com/zerobase/everycampingbackend/product/service/ProductManageService.java
+++ b/src/main/java/com/zerobase/everycampingbackend/product/service/ProductManageService.java
@@ -6,7 +6,7 @@ import com.zerobase.everycampingbackend.product.domain.dto.ProductDetailDto;
 import com.zerobase.everycampingbackend.product.domain.dto.ProductDto;
 import com.zerobase.everycampingbackend.product.domain.entity.Product;
 import com.zerobase.everycampingbackend.product.domain.form.ProductManageForm;
-import com.zerobase.everycampingbackend.product.repository.ProductRepository;
+import com.zerobase.everycampingbackend.product.domain.repository.ProductRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;

--- a/src/main/java/com/zerobase/everycampingbackend/product/service/ProductService.java
+++ b/src/main/java/com/zerobase/everycampingbackend/product/service/ProductService.java
@@ -5,7 +5,7 @@ import com.zerobase.everycampingbackend.common.exception.ErrorCode;
 import com.zerobase.everycampingbackend.product.domain.dto.ProductDetailDto;
 import com.zerobase.everycampingbackend.product.domain.dto.ProductDto;
 import com.zerobase.everycampingbackend.product.domain.form.ProductSearchForm;
-import com.zerobase.everycampingbackend.product.repository.ProductRepository;
+import com.zerobase.everycampingbackend.product.domain.repository.ProductRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,7 +8,10 @@ spring.config.import=myDatabaseInfo.properties
 
 #jpa
 spring.jpa.show-sql = true
-spring.jpa.hibernate.ddl-auto=create
+
+#security
+spring.security.user.name=user
+spring.security.user.password=1234
 
 #logging
 #deeping LV : 1.ERROR 2.WARN 3.INFO 4.DEBUG. 5.TRACE

--- a/src/test/java/com/zerobase/everycampingbackend/product/service/ProductManageServiceTest.java
+++ b/src/test/java/com/zerobase/everycampingbackend/product/service/ProductManageServiceTest.java
@@ -10,7 +10,7 @@ import com.zerobase.everycampingbackend.product.domain.dto.ProductDetailDto;
 import com.zerobase.everycampingbackend.product.domain.dto.ProductDto;
 import com.zerobase.everycampingbackend.product.domain.entity.Product;
 import com.zerobase.everycampingbackend.product.domain.form.ProductManageForm;
-import com.zerobase.everycampingbackend.product.repository.ProductRepository;
+import com.zerobase.everycampingbackend.product.domain.repository.ProductRepository;
 import com.zerobase.everycampingbackend.product.type.ProductCategory;
 import java.util.List;
 import java.util.Optional;

--- a/src/test/java/com/zerobase/everycampingbackend/product/service/ProductServiceTest.java
+++ b/src/test/java/com/zerobase/everycampingbackend/product/service/ProductServiceTest.java
@@ -9,7 +9,7 @@ import com.zerobase.everycampingbackend.product.domain.dto.ProductDetailDto;
 import com.zerobase.everycampingbackend.product.domain.dto.ProductDto;
 import com.zerobase.everycampingbackend.product.domain.entity.Product;
 import com.zerobase.everycampingbackend.product.domain.form.ProductSearchForm;
-import com.zerobase.everycampingbackend.product.repository.ProductRepository;
+import com.zerobase.everycampingbackend.product.domain.repository.ProductRepository;
 import com.zerobase.everycampingbackend.product.type.ProductCategory;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;


### PR DESCRIPTION
Background
---
개발자 간 Repository, Entity의 프로젝트 트리 상 위치가 상이한 문제가 있었다.
또한 검색 기능 테스트용으로 데이터 50만 개, 1:N 관계로 매핑되는 테이블에 400만 개를 삽입하였는데, ddl-auto 옵션이 create이면 이 테스트를 할 때마다 데이터 삽입에 계속해서 긴 시간을 쓰게 된다. 그런데 무조건 update로 두기에는 Entity의 구조를 잡고 있는 개발자가 불편해진다.

Change
---
Repository는 domain/repository 안으로 넣는다.
Entity는 domain/entity 안으로 넣는다.
spring.jpa.hibernate.ddl-auto 옵션 위치 myDatabaseInfo 안으로 변경해 옵션값을 각자 관리한다.

Test
---
Postman을 통해 검색 기능 테스트 완료.

Analatics
---
like문을 이용한 조회임에도 생각한 것보다 응답 시간이 훨씬 빨랐다.
커버링 인덱스, es 사용을 한다 해도 이보다 빠르게 만드는 게 의미가 있을까 싶을 정도였다.
하지만 다중 요청이 들어간다면 유의미한 차이를 낼 수 있을 것 같기에 부하 테스트가 필요할 것 같다.

Discuss
---
테스트용 데이터를 만드는 코드는 프로젝트에 포함하기 애매해 푸쉬하지 않았습니다. 참고하고 싶으시면 따로 알려주세요.