### PR TITLE
AOP-FIELD-VALID-EXCEPTION

### DIFF
--- a/src/main/java/com/zerobase/everycampingbackend/common/exception/ErrorCode.java
+++ b/src/main/java/com/zerobase/everycampingbackend/common/exception/ErrorCode.java
@@ -10,6 +10,8 @@ import lombok.RequiredArgsConstructor;
 public enum ErrorCode {
 
   UNKNOWN_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 예외가 발생했습니다."),
+  ARGUMENT_NOT_VALID_EXCEPTION(HttpStatus.BAD_REQUEST, "필드 값이 올바르지 않습니다."),
+
   ORDER_AMOUNT_UNDER_1000(HttpStatus.BAD_REQUEST, "1000원 이하로는 주문할 수 없습니다."),
 
 

--- a/src/main/java/com/zerobase/everycampingbackend/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/zerobase/everycampingbackend/common/exception/GlobalExceptionHandler.java
@@ -1,10 +1,14 @@
 package com.zerobase.everycampingbackend.common.exception;
 
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -14,16 +18,26 @@ public class GlobalExceptionHandler {
 
   @ExceptionHandler(CustomException.class)
   public ResponseEntity<ExceptionResponse> customRequestException(final CustomException ex) {
-    log.error("api Exception : {} \nstackTrace : {}", ex.getErrorCode(), ex.getStackTrace());
+    log.error("api Exception 발생: {}\nstackTrace : {}", ex.getErrorCode(), ex.getStackTrace());
     return new ResponseEntity<>(
         new ExceptionResponse(ex.getMessage(), ex.getErrorCode()),
         ex.getErrorCode().getHttpStatus());
   }
 
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  public ResponseEntity<BindingExceptionResponse> argumentNotValidException(
+      final MethodArgumentNotValidException ex) {
+    log.error("argumentNotValidException 발생\nmessage : {}\nstackTrace :{}", ex.getMessage(),
+        ex.getStackTrace());
+    return new ResponseEntity<>(
+        new BindingExceptionResponse(ErrorCode.ARGUMENT_NOT_VALID_EXCEPTION.getDetail(),
+            ErrorCode.ARGUMENT_NOT_VALID_EXCEPTION, ex.getBindingResult()),
+        ErrorCode.ARGUMENT_NOT_VALID_EXCEPTION.getHttpStatus());
+  }
+
   @ExceptionHandler(Exception.class)
   public ResponseEntity<ExceptionResponse> unknownException(final Exception ex) {
-    log.error("unknown Exception : {},\nmessage : {} \nstackTrace : {}",
-        ErrorCode.UNKNOWN_EXCEPTION,
+    log.error("unknown Exception 발생\nmessage : {}\nstackTrace : {}",
         ex.getMessage(), ex.getStackTrace());
     return new ResponseEntity<>(
         new ExceptionResponse(ex.getMessage(), ErrorCode.UNKNOWN_EXCEPTION),
@@ -31,11 +45,43 @@ public class GlobalExceptionHandler {
   }
 
   @Getter
-  @ToString
   @AllArgsConstructor
   public static class ExceptionResponse {
 
     private String message;
     private ErrorCode errorCode;
+  }
+
+  @Getter
+  public static class BindingExceptionResponse extends ExceptionResponse {
+
+    List<CustomFieldError> fieldErrorList;
+
+    public BindingExceptionResponse(String message, ErrorCode errorCode,
+        BindingResult bindingResult) {
+      super(message, errorCode);
+
+      this.fieldErrorList = CustomFieldError.from(bindingResult);
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class CustomFieldError {
+
+      private String field;
+      private Object rejectedValue;
+      private String reason;
+
+      public static List<CustomFieldError> from(BindingResult bindingResult) {
+        List<FieldError> fieldErrors = bindingResult.getFieldErrors();
+        return fieldErrors.stream()
+            .map(error -> new CustomFieldError(
+                error.getField(),
+                error.getRejectedValue() == null ?
+                    "" : error.getRejectedValue().toString(),
+                error.getDefaultMessage()))
+            .collect(Collectors.toList());
+      }
+    }
   }
 }


### PR DESCRIPTION
이슈 #14 
---
!!!주의사항!!!
---
### 이 PR은 프로젝트 전체에 영향을 끼침

Background
---
현재 @NotNull, @Min(1) 과 같은 valid 어노테이션 사용 시, 필드 unValid 예외 발생 시 필요 없는 정보를 너무 많이 담은 response를 반환하고 있다.
프론트가 보기 좋은 예외를 받을 수 있도록 수정할 필요가 있다.
또한 백앤드 개발자들의 생산성을 높일 수 있도록 AOP 방식을 적용하는게 좋다.

Change
---
request 가 @valid 규칙을 어길 시 반환하는 메시지가 변했습니다.
예시는 다음과 같습니다.

**기존**

> {
>     "message": "Validation failed for argument [0] in public org.springframework.http.ResponseEntity com.zerobase.everycampingbackend.cart.controller.CartController.createCarts(com.zerobase.everycampingbackend.cart.domain.form.CreateCartForm,java.lang.Long) with 2 errors: [Field error in object 'createCartForm' on field 'customerId': rejected value [null]; codes [NotNull.createCartForm.customerId,NotNull.customerId,NotNull.java.lang.Long,NotNull]; arguments [org.springframework.context.support.DefaultMessageSourceResolvable: codes [createCartForm.customerId,customerId]; arguments []; default message [customerId]]; default message [널이어서는 안됩니다]] [Field error in object 'createCartForm' on field 'count': rejected value [0]; codes [Min.createCartForm.count,Min.count,Min.java.lang.Integer,Min]; arguments [org.springframework.context.support.DefaultMessageSourceResolvable: codes [createCartForm.count,count]; arguments []; default message [count],1]; default message [1 이상이어야 합니다]] ",
>     "errorCode": "UNKNOWN_EXCEPTION"
> }

**변경후**

> {
>     "message": "필드 값이 올바르지 않습니다.",
>     "errorCode": "ARGUMENT_NOT_VALID_EXCEPTION",
>     "fieldErrorList": [
>         {
>             "field": "count",
>             "rejectedValue": "0",
>             "reason": "1 이상이어야 합니다"
>         },
>         {
>             "field": "customerId",
>             "rejectedValue": "",
>             "reason": "널이어서는 안됩니다"
>         }
>     ]
> }



Test
---
포스트맨을 통한 작동 테스트 완료


Discuss
---
원하던 기능이 작동은 하고 있으나, 구조가 그다지 아름답지 않습니다. GlobalExceptionHandler가 너무 많은 내부 클래스를 가지고 있고, 너무 많은 역할을 하고 있습니다.(SRP 위반인 듯 합니다.) 나중에 리팩토링이 필요할 것 같습니다.