### PR TITLE
Static image service

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,10 @@ dependencies {
     annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
     annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
 
+    // AWS
+    implementation 'com.amazonaws:aws-java-sdk-bom:1.12.376'
+    implementation 'com.amazonaws:aws-java-sdk-s3:1.12.380'
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'

--- a/src/main/java/com/zerobase/everycampingbackend/common/config/AwsS3Config.java
+++ b/src/main/java/com/zerobase/everycampingbackend/common/config/AwsS3Config.java
@@ -1,0 +1,30 @@
+package com.zerobase.everycampingbackend.common.config;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AwsS3Config {
+
+    @Value("${aws.s3.accesskey}")
+    private String accessKey;
+    @Value("${aws.s3.secretkey}")
+    private String secretKey;
+
+    @Bean
+    public AmazonS3 amazonS3(){
+        AWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+        return AmazonS3ClientBuilder
+            .standard()
+            .withCredentials(new AWSStaticCredentialsProvider(credentials))
+            .withRegion(Regions.AP_NORTHEAST_2)
+            .build();
+    }
+}

--- a/src/main/java/com/zerobase/everycampingbackend/common/config/SecurityConfiguration.java
+++ b/src/main/java/com/zerobase/everycampingbackend/common/config/SecurityConfiguration.java
@@ -34,6 +34,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
             , "/customers/signup"
             , "/sellers/signin"
             , "/sellers/signup"
+            , "/test/**"
         )
             .permitAll();
 

--- a/src/main/java/com/zerobase/everycampingbackend/common/staticimage/client/AwsS3Client.java
+++ b/src/main/java/com/zerobase/everycampingbackend/common/staticimage/client/AwsS3Client.java
@@ -1,0 +1,48 @@
+package com.zerobase.everycampingbackend.common.staticimage.client;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.zerobase.everycampingbackend.common.staticimage.dto.S3Path;
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Objects;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+@Component
+@RequiredArgsConstructor
+public class AwsS3Client {
+    private final AmazonS3 amazonS3;
+
+    @Value("${aws.s3.bucketname}")
+    private String bucketName;
+    @Value("${aws.s3.endpointurl}")
+    private String endPointUrl;
+
+    public S3Path uploadFileWithUUID(MultipartFile file, String bucketDirPath) throws IOException {
+        String filePath = bucketDirPath + "/" + generateFilename(file);
+
+        ObjectMetadata objectMetadata = new ObjectMetadata();
+        objectMetadata.setContentLength(file.getInputStream().available());
+        amazonS3.putObject(bucketName, filePath, file.getInputStream(), objectMetadata);
+
+        return new S3Path(endPointUrl + "/" + filePath, filePath);
+    }
+
+    private String generateFilename(MultipartFile file){
+        String datetimeStr = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMddhhmmss"));
+        String uuid = datetimeStr + "-" + UUID.randomUUID();
+        String fileName = Objects.requireNonNull(file.getOriginalFilename()).replace(" ", "-");
+
+        return uuid + "-" + fileName;
+    }
+
+    public void deleteFile(String bucketFilePath) {
+        amazonS3.deleteObject(new DeleteObjectRequest(bucketName, bucketFilePath));
+    }
+}

--- a/src/main/java/com/zerobase/everycampingbackend/common/staticimage/dto/S3Path.java
+++ b/src/main/java/com/zerobase/everycampingbackend/common/staticimage/dto/S3Path.java
@@ -1,0 +1,11 @@
+package com.zerobase.everycampingbackend.common.staticimage.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class S3Path {
+    private String imageUri;
+    private String imagePath;
+}

--- a/src/main/java/com/zerobase/everycampingbackend/common/staticimage/service/StaticImageService.java
+++ b/src/main/java/com/zerobase/everycampingbackend/common/staticimage/service/StaticImageService.java
@@ -1,0 +1,54 @@
+package com.zerobase.everycampingbackend.common.staticimage.service;
+
+import com.zerobase.everycampingbackend.common.staticimage.client.AwsS3Client;
+import com.zerobase.everycampingbackend.common.staticimage.dto.S3Path;
+import com.zerobase.everycampingbackend.common.staticimage.type.ImageFormat;
+import java.io.IOException;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.util.ObjectUtils;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class StaticImageService {
+
+    private final AwsS3Client awsS3Client;
+
+    private static final String IMG_DIR_PATH = "img";
+
+    public S3Path saveImage(MultipartFile multipartFile) throws IOException {
+        if(multipartFile.isEmpty()){
+            return new S3Path("", "");
+        }
+
+        int pos = Objects.requireNonNull(multipartFile.getOriginalFilename()).lastIndexOf(".");
+        String extension = multipartFile.getOriginalFilename().substring(pos + 1);
+        if(ObjectUtils.isEmpty(ImageFormat.getExtension(extension))){
+            return new S3Path("", "");
+        }
+
+        return awsS3Client.uploadFileWithUUID(multipartFile, IMG_DIR_PATH);
+    }
+
+    public void deleteImage(String bucketFilePath) {
+        if(ObjectUtils.isEmpty(bucketFilePath)){
+            return;
+        }
+        awsS3Client.deleteFile(bucketFilePath);
+    }
+
+    public S3Path editImage(String bucketFilePath, MultipartFile multipartFile) throws IOException {
+        if(StringUtils.hasText(bucketFilePath)){
+            awsS3Client.deleteFile(bucketFilePath);
+        }
+        if(multipartFile.isEmpty()){
+            return new S3Path("", "");
+        }
+        return awsS3Client.uploadFileWithUUID(multipartFile, IMG_DIR_PATH);
+    }
+}

--- a/src/main/java/com/zerobase/everycampingbackend/common/staticimage/type/ImageFormat.java
+++ b/src/main/java/com/zerobase/everycampingbackend/common/staticimage/type/ImageFormat.java
@@ -1,0 +1,14 @@
+package com.zerobase.everycampingbackend.common.staticimage.type;
+
+import java.util.Arrays;
+
+public enum ImageFormat {
+    JPEG, JPG, PNG, WEBP;
+
+    public static ImageFormat getExtension(String str){
+        return Arrays.stream(values())
+            .filter(e -> e.name().equals(str.toUpperCase()))
+            .findFirst()
+            .orElse(null);
+    }
+}

--- a/src/main/java/com/zerobase/everycampingbackend/product/controller/ProductManageController.java
+++ b/src/main/java/com/zerobase/everycampingbackend/product/controller/ProductManageController.java
@@ -4,6 +4,7 @@ import com.zerobase.everycampingbackend.product.domain.dto.ProductDetailDto;
 import com.zerobase.everycampingbackend.product.domain.dto.ProductDto;
 import com.zerobase.everycampingbackend.product.domain.form.ProductManageForm;
 import com.zerobase.everycampingbackend.product.service.ProductManageService;
+import java.io.IOException;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -29,7 +30,7 @@ public class ProductManageController {
 
     @PostMapping
     public ResponseEntity<Boolean> addProduct(@AuthenticationPrincipal UserDetails user,
-        @RequestBody @Valid ProductManageForm form) {
+        @RequestBody @Valid ProductManageForm form) throws IOException {
         productManageService.addProduct(form);
         return ResponseEntity.ok(true);
     }
@@ -37,7 +38,7 @@ public class ProductManageController {
     @PutMapping("/{productId}")
     public ResponseEntity<Boolean> updateProduct(@AuthenticationPrincipal UserDetails user,
         @PathVariable Long productId,
-        @RequestBody @Valid ProductManageForm form) {
+        @RequestBody @Valid ProductManageForm form) throws IOException {
         productManageService.updateProduct(productId, form);
         return ResponseEntity.ok(true);
     }

--- a/src/main/java/com/zerobase/everycampingbackend/product/domain/dto/ProductDetailDto.java
+++ b/src/main/java/com/zerobase/everycampingbackend/product/domain/dto/ProductDetailDto.java
@@ -24,7 +24,7 @@ public class ProductDetailDto {
     private String description;
     private int stock;
     private int price;
-    private String imagePath;
+    private String detailImageUri;
     private List<String> tags;
     private boolean onSale;
     private int reviewCount;
@@ -42,7 +42,7 @@ public class ProductDetailDto {
             .description(product.getDescription())
             .stock(product.getStock())
             .price(product.getPrice())
-            .imagePath(product.getDetailImagePath())
+            .detailImageUri(product.getDetailImageUri())
             .tags(product.getTags())
             .onSale(product.isOnSale())
             .reviewCount(product.getReviewCount())

--- a/src/main/java/com/zerobase/everycampingbackend/product/domain/dto/ProductDto.java
+++ b/src/main/java/com/zerobase/everycampingbackend/product/domain/dto/ProductDto.java
@@ -21,7 +21,7 @@ public class ProductDto {
     private ProductCategory category;
     private String name;
     private int price;
-    private String imagePath;
+    private String imageUri;
     private int reviewCount;
     private double avgScore;
     private LocalDateTime createdAt;
@@ -34,7 +34,7 @@ public class ProductDto {
             .category(product.getCategory())
             .name(product.getName())
             .price(product.getPrice())
-            .imagePath(product.getImagePath())
+            .imageUri(product.getImageUri())
             .reviewCount(product.getReviewCount())
             .avgScore(product.getReviewCount() == 0 ? 0
                 : product.getTotalScore() / (double) product.getReviewCount())

--- a/src/main/java/com/zerobase/everycampingbackend/product/domain/entity/Product.java
+++ b/src/main/java/com/zerobase/everycampingbackend/product/domain/entity/Product.java
@@ -1,6 +1,7 @@
 package com.zerobase.everycampingbackend.product.domain.entity;
 
 import com.zerobase.everycampingbackend.common.BaseEntity;
+import com.zerobase.everycampingbackend.common.staticimage.dto.S3Path;
 import com.zerobase.everycampingbackend.product.domain.form.ProductManageForm;
 import com.zerobase.everycampingbackend.product.type.ProductCategory;
 import com.zerobase.everycampingbackend.user.domain.entity.Seller;
@@ -42,7 +43,9 @@ public class Product extends BaseEntity {
     private String description;
     private int stock;
     private int price;
+    private String imageUri;
     private String imagePath;
+    private String detailImageUri;
     private String detailImagePath;
     private boolean onSale;
     @ElementCollection
@@ -50,7 +53,7 @@ public class Product extends BaseEntity {
     private int reviewCount;
     private int totalScore;
 
-    public static Product from(ProductManageForm form){
+    public static Product of(ProductManageForm form, S3Path imagePath, S3Path detailImagePath){
         return Product.builder()
             .name(form.getName())
             .category(form.getCategory())
@@ -58,21 +61,25 @@ public class Product extends BaseEntity {
             .onSale(form.getOnSale())
             .stock(form.getStock())
             .description(form.getDescription())
-            .imagePath(form.getImagePath())
-            .detailImagePath(form.getDetailImagePath())
+            .imageUri(imagePath.getImageUri())
+            .imagePath(imagePath.getImagePath())
+            .detailImageUri(detailImagePath.getImageUri())
+            .detailImagePath(detailImagePath.getImagePath())
             .tags(form.getTags())
             .build();
     }
 
-    public void setFrom(ProductManageForm form){
+    public void setOf(ProductManageForm form, S3Path imagePath, S3Path detailImagePath){
         setName(form.getName());
         setCategory(form.getCategory());
         setPrice(form.getPrice());
         setStock(form.getStock());
         setOnSale(form.getOnSale());
         setDescription(form.getDescription());
-        setImagePath(form.getImagePath());
-        setDetailImagePath(form.getDetailImagePath());
+        setImageUri(imagePath.getImageUri());
+        setImagePath(imagePath.getImagePath());
+        setDetailImageUri(detailImagePath.getImageUri());
+        setDetailImagePath(detailImagePath.getImagePath());
         setTags(form.getTags());
     }
 }

--- a/src/main/java/com/zerobase/everycampingbackend/product/domain/form/ProductManageForm.java
+++ b/src/main/java/com/zerobase/everycampingbackend/product/domain/form/ProductManageForm.java
@@ -9,6 +9,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
 
 @Getter
 @Setter
@@ -28,7 +29,7 @@ public class ProductManageForm {
 
     private String description;
     private Integer stock;
-    private String imagePath;
-    private String detailImagePath;
+    private MultipartFile image;
+    private MultipartFile detailImage;
     private List<String> tags;
 }

--- a/src/main/java/com/zerobase/everycampingbackend/product/service/ProductManageService.java
+++ b/src/main/java/com/zerobase/everycampingbackend/product/service/ProductManageService.java
@@ -2,11 +2,14 @@ package com.zerobase.everycampingbackend.product.service;
 
 import com.zerobase.everycampingbackend.common.exception.CustomException;
 import com.zerobase.everycampingbackend.common.exception.ErrorCode;
+import com.zerobase.everycampingbackend.common.staticimage.dto.S3Path;
+import com.zerobase.everycampingbackend.common.staticimage.service.StaticImageService;
 import com.zerobase.everycampingbackend.product.domain.dto.ProductDetailDto;
 import com.zerobase.everycampingbackend.product.domain.dto.ProductDto;
 import com.zerobase.everycampingbackend.product.domain.entity.Product;
 import com.zerobase.everycampingbackend.product.domain.form.ProductManageForm;
 import com.zerobase.everycampingbackend.product.domain.repository.ProductRepository;
+import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -21,27 +24,34 @@ import org.springframework.transaction.annotation.Transactional;
 public class ProductManageService {
 
     private final ProductRepository productRepository;
+    private final StaticImageService staticImageService;
 
     @Transactional
-    public void addProduct(ProductManageForm form) {
+    public void addProduct(ProductManageForm form) throws IOException {
         // 토큰 통해 받아오는 객체에서 판매자 추출
 
         log.info("상품명 (" + form.getName() + ") 추가 시도");
 
-        productRepository.save(Product.from(form));
+        S3Path imagePath = staticImageService.saveImage(form.getImage());
+        S3Path detailImagePath = staticImageService.saveImage(form.getDetailImage());
+
+        productRepository.save(Product.of(form, imagePath, detailImagePath));
 
         log.info("상품명 (" + form.getName() + ") 추가 완료");
     }
 
     @Transactional
-    public void updateProduct(long productId, ProductManageForm form) {
+    public void updateProduct(long productId, ProductManageForm form) throws IOException {
         Product product = getProductById(productId);
 
         // 토큰 통해 받아오는 유저객체와 product 통해 받아오는 유저객체 id 일치 여부 확인
 
         log.info("상품명 (" + form.getName() + ") 수정 시도");
 
-        product.setFrom(form);
+        S3Path imagePath = staticImageService.editImage(product.getImagePath(), form.getImage());
+        S3Path detailImagePath = staticImageService.editImage(product.getImagePath(), form.getDetailImage());
+
+        product.setOf(form, imagePath, detailImagePath);
 
         productRepository.save(product);
 
@@ -62,6 +72,9 @@ public class ProductManageService {
         log.info("상품명 (" + product.getName() + ") 삭제 시도");
 
         productRepository.delete(product);
+
+        staticImageService.deleteImage(product.getImagePath());
+        staticImageService.deleteImage(product.getDetailImagePath());
 
         log.info("상품명 (" + product.getName() + ") 삭제 완료");
     }


### PR DESCRIPTION
Background
---
상품 및 리뷰 등록에 이미지 업로드가 가능하기 때문에 이미지 서버가 필요하였다.
local 환경을 사용해도 됐지만, 이미지 서버로 S3가 인기인 것 같아 사용해보기로 했다.
향후 추가적인 기능이 더 들어갈 것을 고려해 최대한 레이어를 나누어 구성하였다.

Change
---
상품 관리를 통한 이미지 추가/수정/삭제 기능 구현

Test
---
JUnit 테스트를 통해 상품 관리 서비스와 정적 이미지 서비스 간의 연결이 잘 된 것을 확인했다.
Postman을 통해 api 테스트를 진행했고, S3 내 파일 CRUD가 정상적으로 이루어지는 것을 확인했다.

Analatics
---
이미지의 용량이 용량이기에 S3에 업로드하는데 꽤 많은 시간이 소요된다.
수만 명이 동시에 업로드를 한다고 가정하면 어마어마한 시간이 소요될 것이다.
보다 쾌적한 서비스 제공을 위해 이미지 조작용 웹 서버와 애플리케이션 서버의 추가 구축이 필요할 수도 있다.

Discuss
---
저희끼리 정했던 정책과 다르게 Service 내에서 다른 Service를 참조하였습니다.
향후 이미지 서버가 분리된다면 이 service는 client로 바뀔 수도 있어서 그렇게 진행하였습니다.
이에 대해 어떻게 생각하시는 지 회의 때 얘기해 보았으면 합니다.