### PR TITLE
Review crud service

### DIFF
--- a/src/main/java/com/zerobase/everycampingbackend/common/exception/ErrorCode.java
+++ b/src/main/java/com/zerobase/everycampingbackend/common/exception/ErrorCode.java
@@ -22,7 +22,11 @@ public enum ErrorCode {
   PRODUCT_NOT_FOUND(HttpStatus.BAD_REQUEST, "상품을 찾을 수 없습니다."),
   PRODUCT_SELLER_NOT_MATCHED(HttpStatus.BAD_REQUEST, "상품 수정/삭제 권한이 없습니다."),
   PRODUCT_NOT_ENOUGH_STOCK(HttpStatus.BAD_REQUEST, "상품의 재고가 부족합니다."),
-  PRODUCT_NOT_ON_SALE(HttpStatus.BAD_REQUEST, "상품이 판매 중이 아닙니다.")
+  PRODUCT_NOT_ON_SALE(HttpStatus.BAD_REQUEST, "상품이 판매 중이 아닙니다."),
+
+  REVIEW_NOT_FOUND(HttpStatus.BAD_REQUEST, "리뷰를 찾을 수 없습니다."),
+  REVIEW_WRITER_NOT_QUALIFIED(HttpStatus.BAD_REQUEST, "리뷰 작성은 해당 상품을 구매한 고객만 가능합니다."),
+  REVIEW_EDITOR_NOT_MATCHED(HttpStatus.BAD_REQUEST, "리뷰 수정/삭제 권한이 없습니다."),
 
   ;
 

--- a/src/main/java/com/zerobase/everycampingbackend/product/service/ProductService.java
+++ b/src/main/java/com/zerobase/everycampingbackend/product/service/ProductService.java
@@ -52,6 +52,17 @@ public class ProductService {
         productRepository.save(product);
     }
 
+    @Transactional
+    public void deleteReview(Product product, Integer score){
+        product.setTotalScore(product.getTotalScore() - score);
+
+        if(product.getTotalScore() < 0){
+            log.error("상품 내 리뷰 총점이 음수가 됨. 확인 요망.");
+        }
+
+        productRepository.save(product);
+    }
+
     public Product getProductById(Long productId){
         return productRepository.findById(productId)
             .orElseThrow(() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));

--- a/src/main/java/com/zerobase/everycampingbackend/product/service/ProductService.java
+++ b/src/main/java/com/zerobase/everycampingbackend/product/service/ProductService.java
@@ -34,6 +34,24 @@ public class ProductService {
         return result;
     }
 
+    @Transactional
+    public void addReview(Product product, Integer score){
+        product.setReviewCount(product.getReviewCount() + 1);
+        product.setTotalScore(product.getTotalScore() + score);
+        productRepository.save(product);
+    }
+
+    @Transactional
+    public void updateReview(Product product, Integer scoreDiff){
+        product.setTotalScore(product.getTotalScore() + scoreDiff);
+
+        if(product.getTotalScore() < 0){
+            log.error("상품 내 리뷰 총점이 음수가 됨. 확인 요망.");
+        }
+
+        productRepository.save(product);
+    }
+
     public Product getProductById(Long productId){
         return productRepository.findById(productId)
             .orElseThrow(() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));

--- a/src/main/java/com/zerobase/everycampingbackend/review/controller/ReviewController.java
+++ b/src/main/java/com/zerobase/everycampingbackend/review/controller/ReviewController.java
@@ -6,7 +6,9 @@ import java.io.IOException;
 import java.security.Principal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -19,9 +21,19 @@ public class ReviewController {
     private final ReviewService reviewService;
 
     @PostMapping
-    public ResponseEntity<Boolean> writeReview(Principal principal, @RequestBody ReviewForm form)
+    public ResponseEntity<Boolean> writeReview(Principal principal,
+        @RequestBody Long customerId,
+        @RequestBody Long productId,
+        @RequestBody ReviewForm form)
         throws IOException {
-        reviewService.writeReview(principal.getName(), form);
+        reviewService.writeReview(principal.getName(), customerId, productId, form);
+        return ResponseEntity.ok(true);
+    }
+
+    @PutMapping("/{reviewId}")
+    public ResponseEntity<Boolean> editReview(Principal principal,
+        @PathVariable Long reviewId, @RequestBody ReviewForm form) throws IOException {
+        reviewService.editReview(principal.getName(), reviewId, form);
         return ResponseEntity.ok(true);
     }
 

--- a/src/main/java/com/zerobase/everycampingbackend/review/controller/ReviewController.java
+++ b/src/main/java/com/zerobase/everycampingbackend/review/controller/ReviewController.java
@@ -1,7 +1,13 @@
 package com.zerobase.everycampingbackend.review.controller;
 
+import com.zerobase.everycampingbackend.review.domain.form.ReviewForm;
 import com.zerobase.everycampingbackend.review.service.ReviewService;
+import java.io.IOException;
+import java.security.Principal;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -12,5 +18,11 @@ public class ReviewController {
 
     private final ReviewService reviewService;
 
+    @PostMapping
+    public ResponseEntity<Boolean> writeReview(Principal principal, @RequestBody ReviewForm form)
+        throws IOException {
+        reviewService.writeReview(principal.getName(), form);
+        return ResponseEntity.ok(true);
+    }
 
 }

--- a/src/main/java/com/zerobase/everycampingbackend/review/controller/ReviewController.java
+++ b/src/main/java/com/zerobase/everycampingbackend/review/controller/ReviewController.java
@@ -8,6 +8,7 @@ import java.security.Principal;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.util.ObjectUtils;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -49,18 +50,20 @@ public class ReviewController {
     }
 
     @GetMapping("/{reviewId}")
-    public ResponseEntity<ReviewDto> getReviewDetail(@PathVariable Long reviewId){
+    public ResponseEntity<ReviewDto> getReviewDetail(@PathVariable Long reviewId) {
         return ResponseEntity.ok(reviewService.getReviewDetail(reviewId));
     }
 
     @GetMapping
-    public ResponseEntity<List<ReviewDto>> getReviewsByCustomerId(@RequestParam Long customerId){
-        return ResponseEntity.ok(reviewService.getReviewsByCustomerId(customerId));
-    }
-
-    @GetMapping
-    public ResponseEntity<List<ReviewDto>> getReviewsByProductId(@RequestParam Long productId){
-        return ResponseEntity.ok(reviewService.getReviewsByProductId(productId));
+    public ResponseEntity<List<ReviewDto>> getReviewsById(@RequestParam Long customerId,
+        @RequestParam Long productId) {
+        List<ReviewDto> reviews = null;
+        if(!ObjectUtils.isEmpty(customerId)){
+            reviews = reviewService.getReviewsByCustomerId(customerId);
+        } else if(!ObjectUtils.isEmpty(productId)){
+            reviews = reviewService.getReviewsByProductId(productId);
+        }
+        return ResponseEntity.ok(reviews);
     }
 
 }

--- a/src/main/java/com/zerobase/everycampingbackend/review/controller/ReviewController.java
+++ b/src/main/java/com/zerobase/everycampingbackend/review/controller/ReviewController.java
@@ -1,0 +1,16 @@
+package com.zerobase.everycampingbackend.review.controller;
+
+import com.zerobase.everycampingbackend.review.service.ReviewService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/reviews")
+public class ReviewController {
+
+    private final ReviewService reviewService;
+
+
+}

--- a/src/main/java/com/zerobase/everycampingbackend/review/controller/ReviewController.java
+++ b/src/main/java/com/zerobase/everycampingbackend/review/controller/ReviewController.java
@@ -1,17 +1,21 @@
 package com.zerobase.everycampingbackend.review.controller;
 
+import com.zerobase.everycampingbackend.review.domain.dto.ReviewDto;
 import com.zerobase.everycampingbackend.review.domain.form.ReviewForm;
 import com.zerobase.everycampingbackend.review.service.ReviewService;
 import java.io.IOException;
 import java.security.Principal;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -42,6 +46,21 @@ public class ReviewController {
     public ResponseEntity<Boolean> deleteReview(Principal principal, @PathVariable Long reviewId) {
         reviewService.deleteReview(principal.getName(), reviewId);
         return ResponseEntity.ok(true);
+    }
+
+    @GetMapping("/{reviewId}")
+    public ResponseEntity<ReviewDto> getReviewDetail(@PathVariable Long reviewId){
+        return ResponseEntity.ok(reviewService.getReviewDetail(reviewId));
+    }
+
+    @GetMapping
+    public ResponseEntity<List<ReviewDto>> getReviewsByCustomerId(@RequestParam Long customerId){
+        return ResponseEntity.ok(reviewService.getReviewsByCustomerId(customerId));
+    }
+
+    @GetMapping
+    public ResponseEntity<List<ReviewDto>> getReviewsByProductId(@RequestParam Long productId){
+        return ResponseEntity.ok(reviewService.getReviewsByProductId(productId));
     }
 
 }

--- a/src/main/java/com/zerobase/everycampingbackend/review/controller/ReviewController.java
+++ b/src/main/java/com/zerobase/everycampingbackend/review/controller/ReviewController.java
@@ -8,7 +8,6 @@ import java.security.Principal;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.util.ObjectUtils;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -16,7 +15,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController

--- a/src/main/java/com/zerobase/everycampingbackend/review/controller/ReviewController.java
+++ b/src/main/java/com/zerobase/everycampingbackend/review/controller/ReviewController.java
@@ -54,16 +54,14 @@ public class ReviewController {
         return ResponseEntity.ok(reviewService.getReviewDetail(reviewId));
     }
 
-    @GetMapping
-    public ResponseEntity<List<ReviewDto>> getReviewsById(@RequestParam Long customerId,
-        @RequestParam Long productId) {
-        List<ReviewDto> reviews = null;
-        if(!ObjectUtils.isEmpty(customerId)){
-            reviews = reviewService.getReviewsByCustomerId(customerId);
-        } else if(!ObjectUtils.isEmpty(productId)){
-            reviews = reviewService.getReviewsByProductId(productId);
-        }
-        return ResponseEntity.ok(reviews);
+    @GetMapping("/products/{productId}")
+    public ResponseEntity<List<ReviewDto>> getReviewsByProductId(@PathVariable Long productId) {
+        return ResponseEntity.ok(reviewService.getReviewsByProductId(productId));
+    }
+
+    @GetMapping("/customers/{customerId}")
+    public ResponseEntity<List<ReviewDto>> getReviewsByCustomerId(@PathVariable Long customerId) {
+        return ResponseEntity.ok(reviewService.getReviewsByCustomerId(customerId));
     }
 
 }

--- a/src/main/java/com/zerobase/everycampingbackend/review/controller/ReviewController.java
+++ b/src/main/java/com/zerobase/everycampingbackend/review/controller/ReviewController.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.security.Principal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -34,6 +35,12 @@ public class ReviewController {
     public ResponseEntity<Boolean> editReview(Principal principal,
         @PathVariable Long reviewId, @RequestBody ReviewForm form) throws IOException {
         reviewService.editReview(principal.getName(), reviewId, form);
+        return ResponseEntity.ok(true);
+    }
+
+    @DeleteMapping("/{reviewId}")
+    public ResponseEntity<Boolean> deleteReview(Principal principal, @PathVariable Long reviewId) {
+        reviewService.deleteReview(principal.getName(), reviewId);
         return ResponseEntity.ok(true);
     }
 

--- a/src/main/java/com/zerobase/everycampingbackend/review/domain/dto/ReviewDto.java
+++ b/src/main/java/com/zerobase/everycampingbackend/review/domain/dto/ReviewDto.java
@@ -1,0 +1,34 @@
+package com.zerobase.everycampingbackend.review.domain.dto;
+
+import com.zerobase.everycampingbackend.review.domain.entity.Review;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ReviewDto {
+    private Long id;
+    private String customerName;
+    private Integer score;
+    private String text;
+    private String imageUri;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+
+    public static ReviewDto from(Review review){
+        return ReviewDto.builder()
+            .id(review.getId())
+            .customerName(review.getCustomer().getNickName())
+            .score(review.getScore())
+            .text(review.getText())
+            .imageUri(review.getImageUri())
+            .createdAt(review.getCreatedAt())
+            .modifiedAt(review.getModifiedAt())
+            .build();
+    }
+}

--- a/src/main/java/com/zerobase/everycampingbackend/review/domain/entity/Review.java
+++ b/src/main/java/com/zerobase/everycampingbackend/review/domain/entity/Review.java
@@ -51,4 +51,11 @@ public class Review extends BaseEntity {
             .imagePath(s3Path.getImagePath())
             .build();
     }
+
+    public void setOf(ReviewForm form, S3Path s3Path) {
+        score = form.getScore();
+        text = form.getText();
+        imageUri = s3Path.getImageUri();
+        imagePath = s3Path.getImagePath();
+    }
 }

--- a/src/main/java/com/zerobase/everycampingbackend/review/domain/entity/Review.java
+++ b/src/main/java/com/zerobase/everycampingbackend/review/domain/entity/Review.java
@@ -1,7 +1,9 @@
 package com.zerobase.everycampingbackend.review.domain.entity;
 
 import com.zerobase.everycampingbackend.common.BaseEntity;
+import com.zerobase.everycampingbackend.common.staticimage.dto.S3Path;
 import com.zerobase.everycampingbackend.product.domain.entity.Product;
+import com.zerobase.everycampingbackend.review.domain.form.ReviewForm;
 import com.zerobase.everycampingbackend.user.domain.entity.Customer;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -39,4 +41,14 @@ public class Review extends BaseEntity {
     private String imagePath;
 
 
+    public static Review of(ReviewForm form, Customer customer, Product product, S3Path s3Path) {
+        return Review.builder()
+            .customer(customer)
+            .product(product)
+            .score(form.getScore())
+            .text(form.getText())
+            .imageUri(s3Path.getImageUri())
+            .imagePath(s3Path.getImagePath())
+            .build();
+    }
 }

--- a/src/main/java/com/zerobase/everycampingbackend/review/domain/entity/Review.java
+++ b/src/main/java/com/zerobase/everycampingbackend/review/domain/entity/Review.java
@@ -1,0 +1,42 @@
+package com.zerobase.everycampingbackend.review.domain.entity;
+
+import com.zerobase.everycampingbackend.common.BaseEntity;
+import com.zerobase.everycampingbackend.product.domain.entity.Product;
+import com.zerobase.everycampingbackend.user.domain.entity.Customer;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+public class Review extends BaseEntity {
+    @Id
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "customer_id")
+    private Customer customer;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id")
+    private Product product;
+
+    private Integer score;
+    private String text;
+
+    private String imageUri;
+    private String imagePath;
+
+
+}

--- a/src/main/java/com/zerobase/everycampingbackend/review/domain/form/ReviewForm.java
+++ b/src/main/java/com/zerobase/everycampingbackend/review/domain/form/ReviewForm.java
@@ -13,10 +13,6 @@ import org.springframework.web.multipart.MultipartFile;
 @AllArgsConstructor
 public class ReviewForm {
     @NotNull
-    private Long customerId;
-    @NotNull
-    private Long productId;
-    @NotNull
     @Min(1)
     @Max(5)
     private Integer score;

--- a/src/main/java/com/zerobase/everycampingbackend/review/domain/form/ReviewForm.java
+++ b/src/main/java/com/zerobase/everycampingbackend/review/domain/form/ReviewForm.java
@@ -1,0 +1,27 @@
+package com.zerobase.everycampingbackend.review.domain.form;
+
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter
+@AllArgsConstructor
+public class ReviewForm {
+    @NotNull
+    private Long customerId;
+    @NotNull
+    private Long productId;
+    @NotNull
+    @Min(1)
+    @Max(5)
+    private Integer score;
+    @NotBlank
+    @Size(min = 10)
+    private String text;
+    private MultipartFile image;
+}

--- a/src/main/java/com/zerobase/everycampingbackend/review/domain/repository/ReviewRepository.java
+++ b/src/main/java/com/zerobase/everycampingbackend/review/domain/repository/ReviewRepository.java
@@ -1,0 +1,14 @@
+package com.zerobase.everycampingbackend.review.domain.repository;
+
+import com.zerobase.everycampingbackend.product.domain.entity.Product;
+import com.zerobase.everycampingbackend.review.domain.entity.Review;
+import com.zerobase.everycampingbackend.user.domain.entity.Customer;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+    List<Review> findAllByProduct(Product product);
+    List<Review> findAllByCustomer(Customer customer);
+}

--- a/src/main/java/com/zerobase/everycampingbackend/review/service/ReviewService.java
+++ b/src/main/java/com/zerobase/everycampingbackend/review/service/ReviewService.java
@@ -70,6 +70,21 @@ public class ReviewService {
         log.info(userEmail + " -> 리뷰 수정 완료");
     }
 
+    public void deleteReview(String userEmail, Long reviewId) {
+        log.info(userEmail + " -> 리뷰 삭제 시도");
+
+        Review review = getReviewById(reviewId);
+        if (!review.getCustomer().getEmail().equals(userEmail)) {
+            throw new CustomException(ErrorCode.REVIEW_EDITOR_NOT_MATCHED);
+        }
+
+        reviewRepository.delete(review);
+        staticImageService.deleteImage(review.getImagePath());
+        productService.deleteReview(review.getProduct(), review.getScore());
+
+        log.info(userEmail + " -> 리뷰 삭제 완료");
+    }
+
     public Review getReviewById(Long id) {
         return reviewRepository.findById(id)
             .orElseThrow(() -> new CustomException(ErrorCode.REVIEW_NOT_FOUND));

--- a/src/main/java/com/zerobase/everycampingbackend/review/service/ReviewService.java
+++ b/src/main/java/com/zerobase/everycampingbackend/review/service/ReviewService.java
@@ -72,6 +72,7 @@ public class ReviewService {
         log.info(userEmail + " -> 리뷰 수정 완료");
     }
 
+    @Transactional
     public void deleteReview(String userEmail, Long reviewId) {
         log.info(userEmail + " -> 리뷰 삭제 시도");
 

--- a/src/main/java/com/zerobase/everycampingbackend/review/service/ReviewService.java
+++ b/src/main/java/com/zerobase/everycampingbackend/review/service/ReviewService.java
@@ -23,28 +23,54 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class ReviewService {
+
     private final ReviewRepository reviewRepository;
     private final CustomerService customerService;
     private final ProductService productService;
     private final StaticImageService staticImageService;
 
-    public void writeReview(String customerEmail, ReviewForm form) throws IOException {
-        log.info(customerEmail + " -> 리뷰 작성 시도");
-        Customer customer  = customerService.getCustomerById(form.getCustomerId());
+    @Transactional
+    public void writeReview(String userEmail, Long customerId, Long productId, ReviewForm form)
+        throws IOException {
+        log.info(userEmail + " -> 리뷰 작성 시도");
 
-        if(!customer.getEmail().equals(customerEmail)){
+        Customer customer = customerService.getCustomerById(customerId);
+        if (!customer.getEmail().equals(userEmail)) {
             throw new CustomException(ErrorCode.REVIEW_WRITER_NOT_QUALIFIED);
         }
 
-        Product product = productService.getProductById(form.getProductId());
+        Product product = productService.getProductById(productId);
+        // 구매한 상품이 맞는 지에 대한 검증 필요
 
         S3Path s3Path = staticImageService.saveImage(form.getImage());
 
         reviewRepository.save(Review.of(form, customer, product, s3Path));
-        log.info(customerEmail + " -> 리뷰 작성 완료");
+        productService.addReview(product, form.getScore());
+
+        log.info(userEmail + " -> 리뷰 작성 완료");
     }
 
-    public Review getReviewById(Long id){
+    @Transactional
+    public void editReview(String userEmail, Long reviewId, ReviewForm form) throws IOException{
+        log.info(userEmail + " -> 리뷰 수정 시도");
+
+        Review review = getReviewById(reviewId);
+        if (!review.getCustomer().getEmail().equals(userEmail)) {
+            throw new CustomException(ErrorCode.REVIEW_EDITOR_NOT_MATCHED);
+        }
+
+        S3Path s3Path = staticImageService.editImage(review.getImagePath(), form.getImage());
+
+        Integer oldScore = review.getScore();
+        review.setOf(form, s3Path);
+        reviewRepository.save(review);
+
+        productService.updateReview(review.getProduct(), review.getScore() - oldScore);
+
+        log.info(userEmail + " -> 리뷰 수정 완료");
+    }
+
+    public Review getReviewById(Long id) {
         return reviewRepository.findById(id)
             .orElseThrow(() -> new CustomException(ErrorCode.REVIEW_NOT_FOUND));
     }

--- a/src/main/java/com/zerobase/everycampingbackend/review/service/ReviewService.java
+++ b/src/main/java/com/zerobase/everycampingbackend/review/service/ReviewService.java
@@ -2,10 +2,16 @@ package com.zerobase.everycampingbackend.review.service;
 
 import com.zerobase.everycampingbackend.common.exception.CustomException;
 import com.zerobase.everycampingbackend.common.exception.ErrorCode;
+import com.zerobase.everycampingbackend.common.staticimage.dto.S3Path;
+import com.zerobase.everycampingbackend.common.staticimage.service.StaticImageService;
 import com.zerobase.everycampingbackend.product.domain.entity.Product;
+import com.zerobase.everycampingbackend.product.service.ProductService;
 import com.zerobase.everycampingbackend.review.domain.entity.Review;
+import com.zerobase.everycampingbackend.review.domain.form.ReviewForm;
 import com.zerobase.everycampingbackend.review.domain.repository.ReviewRepository;
 import com.zerobase.everycampingbackend.user.domain.entity.Customer;
+import com.zerobase.everycampingbackend.user.service.CustomerService;
+import java.io.IOException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,8 +24,25 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class ReviewService {
     private final ReviewRepository reviewRepository;
+    private final CustomerService customerService;
+    private final ProductService productService;
+    private final StaticImageService staticImageService;
 
+    public void writeReview(String customerEmail, ReviewForm form) throws IOException {
+        log.info(customerEmail + " -> 리뷰 작성 시도");
+        Customer customer  = customerService.getCustomerById(form.getCustomerId());
 
+        if(!customer.getEmail().equals(customerEmail)){
+            throw new CustomException(ErrorCode.REVIEW_WRITER_NOT_QUALIFIED);
+        }
+
+        Product product = productService.getProductById(form.getProductId());
+
+        S3Path s3Path = staticImageService.saveImage(form.getImage());
+
+        reviewRepository.save(Review.of(form, customer, product, s3Path));
+        log.info(customerEmail + " -> 리뷰 작성 완료");
+    }
 
     public Review getReviewById(Long id){
         return reviewRepository.findById(id)

--- a/src/main/java/com/zerobase/everycampingbackend/review/service/ReviewService.java
+++ b/src/main/java/com/zerobase/everycampingbackend/review/service/ReviewService.java
@@ -1,0 +1,37 @@
+package com.zerobase.everycampingbackend.review.service;
+
+import com.zerobase.everycampingbackend.common.exception.CustomException;
+import com.zerobase.everycampingbackend.common.exception.ErrorCode;
+import com.zerobase.everycampingbackend.product.domain.entity.Product;
+import com.zerobase.everycampingbackend.review.domain.entity.Review;
+import com.zerobase.everycampingbackend.review.domain.repository.ReviewRepository;
+import com.zerobase.everycampingbackend.user.domain.entity.Customer;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ReviewService {
+    private final ReviewRepository reviewRepository;
+
+
+
+    public Review getReviewById(Long id){
+        return reviewRepository.findById(id)
+            .orElseThrow(() -> new CustomException(ErrorCode.REVIEW_NOT_FOUND));
+    }
+
+    public List<Review> getReviewsByCustomer(Customer customer) {
+        return reviewRepository.findAllByCustomer(customer);
+    }
+
+    public List<Review> getReviewsByProduct(Product product) {
+        return reviewRepository.findAllByProduct(product);
+    }
+
+}

--- a/src/main/java/com/zerobase/everycampingbackend/review/service/ReviewService.java
+++ b/src/main/java/com/zerobase/everycampingbackend/review/service/ReviewService.java
@@ -6,6 +6,7 @@ import com.zerobase.everycampingbackend.common.staticimage.dto.S3Path;
 import com.zerobase.everycampingbackend.common.staticimage.service.StaticImageService;
 import com.zerobase.everycampingbackend.product.domain.entity.Product;
 import com.zerobase.everycampingbackend.product.service.ProductService;
+import com.zerobase.everycampingbackend.review.domain.dto.ReviewDto;
 import com.zerobase.everycampingbackend.review.domain.entity.Review;
 import com.zerobase.everycampingbackend.review.domain.form.ReviewForm;
 import com.zerobase.everycampingbackend.review.domain.repository.ReviewRepository;
@@ -13,6 +14,7 @@ import com.zerobase.everycampingbackend.user.domain.entity.Customer;
 import com.zerobase.everycampingbackend.user.service.CustomerService;
 import java.io.IOException;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -85,17 +87,24 @@ public class ReviewService {
         log.info(userEmail + " -> 리뷰 삭제 완료");
     }
 
+    public ReviewDto getReviewDetail(Long reviewId) {
+        return ReviewDto.from(getReviewById(reviewId));
+    }
+
+    public List<ReviewDto> getReviewsByCustomerId(Long customerId) {
+        Customer customer = customerService.getCustomerById(customerId);
+        return reviewRepository.findAllByCustomer(customer)
+            .stream().map(ReviewDto::from).collect(Collectors.toList());
+    }
+
+    public List<ReviewDto> getReviewsByProductId(Long productId) {
+        Product product = productService.getProductById(productId);
+        return reviewRepository.findAllByProduct(product)
+            .stream().map(ReviewDto::from).collect(Collectors.toList());
+    }
+
     public Review getReviewById(Long id) {
         return reviewRepository.findById(id)
             .orElseThrow(() -> new CustomException(ErrorCode.REVIEW_NOT_FOUND));
     }
-
-    public List<Review> getReviewsByCustomer(Customer customer) {
-        return reviewRepository.findAllByCustomer(customer);
-    }
-
-    public List<Review> getReviewsByProduct(Product product) {
-        return reviewRepository.findAllByProduct(product);
-    }
-
 }

--- a/src/test/java/com/zerobase/everycampingbackend/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/zerobase/everycampingbackend/review/service/ReviewServiceTest.java
@@ -1,0 +1,279 @@
+package com.zerobase.everycampingbackend.review.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import com.zerobase.everycampingbackend.common.exception.CustomException;
+import com.zerobase.everycampingbackend.common.exception.ErrorCode;
+import com.zerobase.everycampingbackend.common.staticimage.dto.S3Path;
+import com.zerobase.everycampingbackend.common.staticimage.service.StaticImageService;
+import com.zerobase.everycampingbackend.product.domain.entity.Product;
+import com.zerobase.everycampingbackend.product.service.ProductService;
+import com.zerobase.everycampingbackend.review.domain.dto.ReviewDto;
+import com.zerobase.everycampingbackend.review.domain.entity.Review;
+import com.zerobase.everycampingbackend.review.domain.form.ReviewForm;
+import com.zerobase.everycampingbackend.review.domain.repository.ReviewRepository;
+import com.zerobase.everycampingbackend.user.domain.entity.Customer;
+import com.zerobase.everycampingbackend.user.service.CustomerService;
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@TestPropertySource(locations = "classpath:application-test.properties")
+@TestInstance(TestInstance.Lifecycle.PER_METHOD)
+@Transactional
+class ReviewServiceTest {
+
+    @Mock
+    private ReviewRepository reviewRepository;
+    @Mock
+    private CustomerService customerService;
+    @Mock
+    private ProductService productService;
+    @Mock
+    private StaticImageService staticImageService;
+    @InjectMocks
+    private ReviewService reviewService;
+
+    private final ReviewForm form = new ReviewForm(1, "리뷰", null);
+    private String userEmail = "aaa";
+    private final Customer customer = Customer.builder().id(1L).email("aaa").build();
+    private final Product product = Product.builder().id(1L).build();
+    private final Review review = Review.builder()
+        .id(1L)
+        .customer(customer)
+        .product(product)
+        .score(5)
+        .text("리뷰아님")
+        .build();
+    private final S3Path s3Path = new S3Path("uri", "path");
+
+    @Test
+    @DisplayName("리뷰 작성 성공")
+    void success_writeReview() throws IOException {
+        // given
+        given(customerService.getCustomerById(anyLong()))
+            .willReturn(customer);
+        given(productService.getProductById(anyLong()))
+            .willReturn(product);
+        given(staticImageService.saveImage(any()))
+            .willReturn(s3Path);
+        ArgumentCaptor<Review> captor = ArgumentCaptor.forClass(Review.class);
+
+        // when
+        reviewService.writeReview(userEmail, 1L, 1L, form);
+
+        // then
+        verify(reviewRepository).save(captor.capture());
+        assertEquals(product.getId(), captor.getValue().getProduct().getId());
+        assertEquals(customer.getId(), captor.getValue().getCustomer().getId());
+        assertEquals(s3Path.getImageUri(), captor.getValue().getImageUri());
+        assertEquals(s3Path.getImagePath(), captor.getValue().getImagePath());
+        assertEquals(form.getScore(), captor.getValue().getScore());
+        assertEquals(form.getText(), captor.getValue().getText());
+    }
+
+    @Test
+    @DisplayName("리뷰 작성 실패 - 로그인 유저와 폼 유저 정보 불일치")
+    void fail_writeReview_customerNotMatched(){
+        // given
+        userEmail = "eeeee";
+        given(customerService.getCustomerById(anyLong()))
+            .willReturn(customer);
+
+        // when
+        CustomException exception = assertThrows(CustomException.class, () ->
+            reviewService.writeReview(userEmail, 1L, 1L, form));
+
+        // then
+        assertEquals(ErrorCode.REVIEW_WRITER_NOT_QUALIFIED, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("리뷰 수정 성공")
+    void success_editReview() throws IOException {
+        // given
+        review.setImageUri("fjweifjwofowjfowef");
+        review.setImagePath("vmvermvpermvpermpver");
+        given(reviewRepository.findById(anyLong()))
+            .willReturn(Optional.of(review));
+        given(staticImageService.editImage(anyString(), any()))
+            .willReturn(s3Path);
+        ArgumentCaptor<Review> captor = ArgumentCaptor.forClass(Review.class);
+
+        // when
+        reviewService.editReview(userEmail, 1L, form);
+
+        // then
+        verify(reviewRepository).save(captor.capture());
+        assertEquals(s3Path.getImageUri(), captor.getValue().getImageUri());
+        assertEquals(s3Path.getImagePath(), captor.getValue().getImagePath());
+        assertEquals(form.getScore(), captor.getValue().getScore());
+        assertEquals(form.getText(), captor.getValue().getText());
+    }
+
+    @Test
+    @DisplayName("리뷰 수정 실패 - 해당 리뷰 없음")
+    void fail_editReview_reviewNotFound(){
+        // given
+        userEmail = "not-matched-user";
+        given(reviewRepository.findById(anyLong()))
+            .willReturn(Optional.empty());
+
+        // when
+        CustomException exception = assertThrows(CustomException.class, () ->
+            reviewService.editReview(userEmail, 1L, form));
+
+        // then
+        assertEquals(ErrorCode.REVIEW_NOT_FOUND, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("리뷰 수정 실패 - 해당 리뷰 수정 권한 없음")
+    void fail_editReview_userNotEditor(){
+        // given
+        userEmail = "not-matched-user";
+        given(reviewRepository.findById(anyLong()))
+            .willReturn(Optional.of(review));
+
+        // when
+        CustomException exception = assertThrows(CustomException.class, () ->
+            reviewService.editReview(userEmail, 1L, form));
+
+        // then
+        assertEquals(ErrorCode.REVIEW_EDITOR_NOT_MATCHED, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("리뷰 삭제 성공")
+    void success_deleteReview(){
+        // given
+        given(reviewRepository.findById(anyLong()))
+            .willReturn(Optional.of(review));
+        ArgumentCaptor<Review> captor = ArgumentCaptor.forClass(Review.class);
+
+        // when
+        reviewService.deleteReview(userEmail, 1L);
+
+        // then
+        verify(reviewRepository).delete(captor.capture());
+    }
+
+    @Test
+    @DisplayName("리뷰 삭제 실패 - 해당 리뷰 없음")
+    void fail_deleteReview_reviewNotFound(){
+        // given
+        given(reviewRepository.findById(anyLong()))
+            .willReturn(Optional.empty());
+
+        // when
+        CustomException exception = assertThrows(CustomException.class, () ->
+            reviewService.deleteReview(userEmail, 1L));
+
+        // then
+        assertEquals(ErrorCode.REVIEW_NOT_FOUND, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("리뷰 삭제 실패 - 리뷰 삭제 권한 없음")
+    void fail_deleteReview_userNotEditor(){
+        // given
+        userEmail = "wfqwfqf";
+        given(reviewRepository.findById(anyLong()))
+            .willReturn(Optional.of(review));
+
+        // when
+        CustomException exception = assertThrows(CustomException.class, () ->
+            reviewService.deleteReview(userEmail, 1L));
+
+        // then
+        assertEquals(ErrorCode.REVIEW_EDITOR_NOT_MATCHED, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("리뷰 조회 성공")
+    void success_getReviewDetail(){
+        // given
+        given(reviewRepository.findById(anyLong()))
+            .willReturn(Optional.of(review));
+
+        // when
+        ReviewDto result = reviewService.getReviewDetail(1L);
+
+        // then
+        assertEquals(review.getScore(), result.getScore());
+        assertEquals(review.getText(), result.getText());
+        assertEquals(review.getImageUri(), result.getImageUri());
+        assertEquals(review.getCustomer().getNickName(), result.getCustomerName());
+    }
+
+    @Test
+    @DisplayName("리뷰 조회 실패 - 해당 리뷰 없음")
+    void fail_getReviewDetail_reviewNotFound(){
+        // given
+        given(reviewRepository.findById(anyLong()))
+            .willReturn(Optional.empty());
+
+        // when
+        CustomException exception = assertThrows(CustomException.class, () ->
+            reviewService.getReviewDetail(1L));
+
+        // then
+        assertEquals(ErrorCode.REVIEW_NOT_FOUND, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("유저별 리뷰 조회 성공")
+    void success_getReviewsByCustomerId(){
+        // given
+        List<Review> list = List.of(review);
+        given(customerService.getCustomerById(anyLong()))
+            .willReturn(customer);
+        given(reviewRepository.findAllByCustomer(any()))
+            .willReturn(list);
+
+        // when
+        List<ReviewDto> result = reviewService.getReviewsByCustomerId(1L);
+
+        // then
+        assertEquals(review.getScore(), result.get(0).getScore());
+        assertEquals(review.getText(), result.get(0).getText());
+        assertEquals(review.getImageUri(), result.get(0).getImageUri());
+        assertEquals(review.getCustomer().getNickName(), result.get(0).getCustomerName());
+    }
+
+    @Test
+    @DisplayName("상품별 리뷰 조회 성공")
+    void success_getReviewsByProductId(){
+        // given
+        List<Review> list = List.of(review);
+        given(productService.getProductById(anyLong()))
+            .willReturn(product);
+        given(reviewRepository.findAllByProduct(any()))
+            .willReturn(list);
+
+        // when
+        List<ReviewDto> result = reviewService.getReviewsByProductId(1L);
+
+        // then
+        assertEquals(review.getScore(), result.get(0).getScore());
+        assertEquals(review.getText(), result.get(0).getText());
+        assertEquals(review.getImageUri(), result.get(0).getImageUri());
+        assertEquals(review.getCustomer().getNickName(), result.get(0).getCustomerName());
+    }
+}


### PR DESCRIPTION
Background
---
리뷰는 해당 상품을 구매한 고객만 작성 가능하기에 이 부분에 대한 검증이 필요하다.
판매자는 리뷰 조회 외에 어떠한 권한도 없다.
해당 리뷰의 작성자와 관리자만이 수정/삭제 권한을 가진다.

Change
---
리뷰 추가/수정/삭제 로직을 추가하였다.
리뷰의 추가/수정/삭제에 따른 상품 내 리뷰 수, 총점 변경 로직을 추가하였다.

Test
---
Mokito 이용한 테스트 설계 및 확인 완료.

Analatics
---
관리자 추가 이후 리뷰 파트의 수정이 필요하다.

Discuss
---
고객의 리뷰를 조회하는가 (유저에서 리뷰 참조), 리뷰 중 해당 유저가 작성한 것을 조회하는가(리뷰에서 유저 참조)의 관점 관련해 약간의 고민사항이 있었습니다.
기본적으로 리뷰는 유저, 상품 정보를 포함하기에 검증을 위한 해당 서비스 참조가 필요합니다. 이때, 상대쪽에서도 리뷰 서비스의 참조가 필요할 시에 상호 참조가 되어 Bean 생성 관련 에러가 발생합니다.
당장은 리뷰에서 유저를 참조하는 방식으로 모든 것을 해결 하는 구조로 설계하였기에 상호 참조는 피하였지만, 이에 대한 정책 결정이 필요할 것 같습니다.