### PR TITLE
Cart RUD Service

### DIFF
--- a/src/main/java/com/zerobase/everycampingbackend/cart/controller/CartController.java
+++ b/src/main/java/com/zerobase/everycampingbackend/cart/controller/CartController.java
@@ -1,14 +1,19 @@
 package com.zerobase.everycampingbackend.cart.controller;
 
+import com.zerobase.everycampingbackend.cart.domain.dto.CartProductDto;
 import com.zerobase.everycampingbackend.cart.domain.form.CreateCartForm;
 import com.zerobase.everycampingbackend.cart.service.CartService;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -16,11 +21,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class CartController {
 
-  CartService cartService;
+  private final CartService cartService;
+
   /**
    * 장바구니에 물건 추가 원래는 token을 받아서, 토큰정보를 통해 로그인한 유저의 정보를 알아낸 다음,
-   * 해당 유저의 장바구니에 상품을 추가해야 한다.
-   * 현재 token을받아서 사용하는 방법이 정립되지 않았기 때문에 임시로 Customer_id(pk)를 받도록 구현하였음.
+   * 해당 유저의 장바구니에 상품을 추가해야 한다. 현재
+   * token을받아서 사용하는 방법이 정립되지 않았기 때문에 임시로 Customer_id(pk)를 받도록 구현하였음.
    */
   @PostMapping("/add/{productId}")
   public ResponseEntity createCarts(@RequestBody @Valid CreateCartForm form,
@@ -28,6 +34,15 @@ public class CartController {
 
     cartService.createCart(form, productId);
     return ResponseEntity.ok().build();
+  }
+
+  /**
+   * 원래는 토큰을 받아야 하지만, 임시로 customerId를 받는다.
+   */
+  @GetMapping
+  public ResponseEntity<Page<CartProductDto>> getCartProductList(@RequestParam Long customerId,
+      Pageable pageable) {
+    return ResponseEntity.ok(cartService.getCartProductList(customerId, pageable));
   }
 
 }

--- a/src/main/java/com/zerobase/everycampingbackend/cart/controller/CartController.java
+++ b/src/main/java/com/zerobase/everycampingbackend/cart/controller/CartController.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -58,4 +59,11 @@ public class CartController {
     return ResponseEntity.ok().build();
   }
 
+  @DeleteMapping("/{productId}")
+  public ResponseEntity deleteCartProduct(@RequestBody @NotNull Long customerId,
+      @PathVariable Long productId) {
+
+    cartService.deleteCartProduct(productId, customerId);
+    return ResponseEntity.ok().build();
+  }
 }

--- a/src/main/java/com/zerobase/everycampingbackend/cart/controller/CartController.java
+++ b/src/main/java/com/zerobase/everycampingbackend/cart/controller/CartController.java
@@ -25,45 +25,44 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class CartController {
 
-  private final CartService cartService;
+    private final CartService cartService;
 
-  /**
-   * 장바구니에 물건 추가 원래는 token을 받아서, 토큰정보를 통해 로그인한 유저의 정보를 알아낸 다음,
-   * 해당 유저의 장바구니에 상품을 추가해야 한다. 현재
-   * token을받아서 사용하는 방법이 정립되지 않았기 때문에 임시로 Customer_id(pk)를 받도록 구현하였음.
-   */
-  @PostMapping("/add/{productId}")
-  public ResponseEntity createCarts(@RequestBody @Valid CreateCartForm form,
-      @PathVariable Long productId) {
+    /**
+     * 장바구니에 물건 추가 원래는 token을 받아서, 토큰정보를 통해 로그인한 유저의 정보를 알아낸 다음, 해당 유저의 장바구니에 상품을 추가해야 한다. 현재
+     * token을받아서 사용하는 방법이 정립되지 않았기 때문에 임시로 Customer_id(pk)를 받도록 구현하였음.
+     */
+    @PostMapping("/add/{productId}")
+    public ResponseEntity createCarts(@RequestBody @Valid CreateCartForm form,
+        @PathVariable Long productId) {
 
-    cartService.createCart(form, productId);
-    return ResponseEntity.ok().build();
-  }
+        cartService.createCart(form, productId);
+        return ResponseEntity.ok().build();
+    }
 
-  /**
-   * 원래는 토큰을 받아야 하지만, 임시로 customerId를 받는다.
-   */
-  @GetMapping
-  public ResponseEntity<Page<CartProductDto>> getCartProductList(
-      @RequestParam @Valid @NotNull Long customerId,
-      Pageable pageable) {
+    /**
+     * 원래는 토큰을 받아야 하지만, 임시로 customerId를 받는다.
+     */
+    @GetMapping
+    public ResponseEntity<Page<CartProductDto>> getCartProductList(
+        @RequestParam @Valid @NotNull Long customerId,
+        Pageable pageable) {
 
-    return ResponseEntity.ok(cartService.getCartProductList(customerId, pageable));
-  }
+        return ResponseEntity.ok(cartService.getCartProductList(customerId, pageable));
+    }
 
-  @PatchMapping("/{productId}")
-  public ResponseEntity updateQuantity(@RequestBody @Valid UpdateQuantityForm updateQuantityForm,
-      @PathVariable Long productId) {
+    @PatchMapping("/{productId}")
+    public ResponseEntity updateQuantity(@RequestBody @Valid UpdateQuantityForm updateQuantityForm,
+        @PathVariable Long productId) {
 
-    cartService.updateQuantity(productId, updateQuantityForm);
-    return ResponseEntity.ok().build();
-  }
+        cartService.updateQuantity(productId, updateQuantityForm);
+        return ResponseEntity.ok().build();
+    }
 
-  @DeleteMapping("/{productId}")
-  public ResponseEntity deleteCartProduct(@RequestBody @NotNull Long customerId,
-      @PathVariable Long productId) {
+    @DeleteMapping("/{productId}")
+    public ResponseEntity deleteCartProduct(@RequestBody @NotNull Long customerId,
+        @PathVariable Long productId) {
 
-    cartService.deleteCartProduct(productId, customerId);
-    return ResponseEntity.ok().build();
-  }
+        cartService.deleteCartProduct(productId, customerId);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/zerobase/everycampingbackend/cart/controller/CartController.java
+++ b/src/main/java/com/zerobase/everycampingbackend/cart/controller/CartController.java
@@ -2,13 +2,16 @@ package com.zerobase.everycampingbackend.cart.controller;
 
 import com.zerobase.everycampingbackend.cart.domain.dto.CartProductDto;
 import com.zerobase.everycampingbackend.cart.domain.form.CreateCartForm;
+import com.zerobase.everycampingbackend.cart.domain.form.UpdateQuantityForm;
 import com.zerobase.everycampingbackend.cart.service.CartService;
 import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -40,9 +43,19 @@ public class CartController {
    * 원래는 토큰을 받아야 하지만, 임시로 customerId를 받는다.
    */
   @GetMapping
-  public ResponseEntity<Page<CartProductDto>> getCartProductList(@RequestParam Long customerId,
+  public ResponseEntity<Page<CartProductDto>> getCartProductList(
+      @RequestParam @Valid @NotNull Long customerId,
       Pageable pageable) {
+
     return ResponseEntity.ok(cartService.getCartProductList(customerId, pageable));
+  }
+
+  @PatchMapping("/{productId}")
+  public ResponseEntity updateQuantity(@RequestBody @Valid UpdateQuantityForm updateQuantityForm,
+      @PathVariable Long productId) {
+
+    cartService.updateQuantity(productId, updateQuantityForm);
+    return ResponseEntity.ok().build();
   }
 
 }

--- a/src/main/java/com/zerobase/everycampingbackend/cart/domain/dto/CartProductDto.java
+++ b/src/main/java/com/zerobase/everycampingbackend/cart/domain/dto/CartProductDto.java
@@ -1,0 +1,36 @@
+package com.zerobase.everycampingbackend.cart.domain.dto;
+
+import com.zerobase.everycampingbackend.cart.domain.entity.CartProduct;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class CartProductDto {
+
+  private Long productId; //상품 id
+  private String name; //상품 이름
+  private String imagePath;
+  private Integer price; //상품 가격
+  private Boolean onSale; //판매여부
+  private Integer quantity; //장바구니 등록 수량
+  Boolean isCountChanged; //count 변경 여부(재고부족 등으로 인하여 등록 수량이 변했는지 여부)
+
+  public static CartProductDto of(CartProduct cartProduct, Boolean isCountChanged) {
+    return CartProductDto.builder()
+        .productId(cartProduct.getProduct().getId())
+        .name(cartProduct.getProduct().getName())
+        .imagePath(cartProduct.getProduct().getImagePath())
+        .price(cartProduct.getProduct().getPrice())
+        .onSale(cartProduct.getProduct().isOnSale())
+        .quantity(cartProduct.getQuantity())
+        .isCountChanged(isCountChanged)
+        .build();
+  }
+}

--- a/src/main/java/com/zerobase/everycampingbackend/cart/domain/dto/CartProductDto.java
+++ b/src/main/java/com/zerobase/everycampingbackend/cart/domain/dto/CartProductDto.java
@@ -14,23 +14,23 @@ import lombok.ToString;
 @AllArgsConstructor
 public class CartProductDto {
 
-  private Long productId; //상품 id
-  private String name; //상품 이름
-  private String imagePath;
-  private Integer price; //상품 가격
-  private Boolean onSale; //판매여부
-  private Integer quantity; //장바구니 등록 수량
-  Boolean isQuantityChanged; //quantity 변경 여부(재고부족 등으로 인하여 등록 수량이 변했는지 여부)
+    private Long productId; //상품 id
+    private String name; //상품 이름
+    private String imagePath;
+    private Integer price; //상품 가격
+    private Boolean onSale; //판매여부
+    private Integer quantity; //장바구니 등록 수량
+    Boolean isQuantityChanged; //quantity 변경 여부(재고부족 등으로 인하여 등록 수량이 변했는지 여부)
 
-  public static CartProductDto of(CartProduct cartProduct, Boolean isCountChanged) {
-    return CartProductDto.builder()
-        .productId(cartProduct.getProduct().getId())
-        .name(cartProduct.getProduct().getName())
-        .imagePath(cartProduct.getProduct().getImagePath())
-        .price(cartProduct.getProduct().getPrice())
-        .onSale(cartProduct.getProduct().isOnSale())
-        .quantity(cartProduct.getQuantity())
-        .isQuantityChanged(isCountChanged)
-        .build();
-  }
+    public static CartProductDto of(CartProduct cartProduct, Boolean isCountChanged) {
+        return CartProductDto.builder()
+            .productId(cartProduct.getProduct().getId())
+            .name(cartProduct.getProduct().getName())
+            .imagePath(cartProduct.getProduct().getImagePath())
+            .price(cartProduct.getProduct().getPrice())
+            .onSale(cartProduct.getProduct().isOnSale())
+            .quantity(cartProduct.getQuantity())
+            .isQuantityChanged(isCountChanged)
+            .build();
+    }
 }

--- a/src/main/java/com/zerobase/everycampingbackend/cart/domain/dto/CartProductDto.java
+++ b/src/main/java/com/zerobase/everycampingbackend/cart/domain/dto/CartProductDto.java
@@ -20,7 +20,7 @@ public class CartProductDto {
   private Integer price; //상품 가격
   private Boolean onSale; //판매여부
   private Integer quantity; //장바구니 등록 수량
-  Boolean isCountChanged; //count 변경 여부(재고부족 등으로 인하여 등록 수량이 변했는지 여부)
+  Boolean isQuantityChanged; //quantity 변경 여부(재고부족 등으로 인하여 등록 수량이 변했는지 여부)
 
   public static CartProductDto of(CartProduct cartProduct, Boolean isCountChanged) {
     return CartProductDto.builder()
@@ -30,7 +30,7 @@ public class CartProductDto {
         .price(cartProduct.getProduct().getPrice())
         .onSale(cartProduct.getProduct().isOnSale())
         .quantity(cartProduct.getQuantity())
-        .isCountChanged(isCountChanged)
+        .isQuantityChanged(isCountChanged)
         .build();
   }
 }

--- a/src/main/java/com/zerobase/everycampingbackend/cart/domain/entity/CartProduct.java
+++ b/src/main/java/com/zerobase/everycampingbackend/cart/domain/entity/CartProduct.java
@@ -22,7 +22,7 @@ import lombok.Setter;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class Cart extends BaseEntity {
+public class CartProduct extends BaseEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -38,11 +38,11 @@ public class Cart extends BaseEntity {
   @JoinColumn(name = "product_id")
   private Product product;
 
-  private Integer count;
+  private Integer quantity;
 
-  public static Cart of(Product product, Customer customer, Integer count){
-    return Cart.builder()
-        .count(count)
+  public static CartProduct of(Product product, Customer customer, Integer count){
+    return CartProduct.builder()
+        .quantity(count)
         .customer(customer)
         .product(product)
         .build();

--- a/src/main/java/com/zerobase/everycampingbackend/cart/domain/entity/CartProduct.java
+++ b/src/main/java/com/zerobase/everycampingbackend/cart/domain/entity/CartProduct.java
@@ -24,27 +24,27 @@ import lombok.Setter;
 @AllArgsConstructor
 public class CartProduct extends BaseEntity {
 
-  @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
-  private Long id;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
-  //N:1 단방향
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "customer_id")
-  private Customer customer;
+    //N:1 단방향
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "customer_id")
+    private Customer customer;
 
-  //N:1 단방향
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "product_id")
-  private Product product;
+    //N:1 단방향
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id")
+    private Product product;
 
-  private Integer quantity;
+    private Integer quantity;
 
-  public static CartProduct of(Product product, Customer customer, Integer count){
-    return CartProduct.builder()
-        .quantity(count)
-        .customer(customer)
-        .product(product)
-        .build();
-  }
+    public static CartProduct of(Product product, Customer customer, Integer count) {
+        return CartProduct.builder()
+            .quantity(count)
+            .customer(customer)
+            .product(product)
+            .build();
+    }
 }

--- a/src/main/java/com/zerobase/everycampingbackend/cart/domain/form/CreateCartForm.java
+++ b/src/main/java/com/zerobase/everycampingbackend/cart/domain/form/CreateCartForm.java
@@ -17,5 +17,5 @@ public class CreateCartForm {
   Long customerId;
 
   @Min(1)
-  Integer count;
+  Integer quantity;
 }

--- a/src/main/java/com/zerobase/everycampingbackend/cart/domain/form/CreateCartForm.java
+++ b/src/main/java/com/zerobase/everycampingbackend/cart/domain/form/CreateCartForm.java
@@ -13,9 +13,9 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class CreateCartForm {
 
-  @NotNull
-  Long customerId;
+    @NotNull
+    Long customerId;
 
-  @Min(1)
-  Integer quantity;
+    @Min(1)
+    Integer quantity;
 }

--- a/src/main/java/com/zerobase/everycampingbackend/cart/domain/form/UpdateQuantityForm.java
+++ b/src/main/java/com/zerobase/everycampingbackend/cart/domain/form/UpdateQuantityForm.java
@@ -1,0 +1,21 @@
+package com.zerobase.everycampingbackend.cart.domain.form;
+
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateQuantityForm {
+
+  @NotNull
+  Long customerId;
+
+  @Min(1)
+  Integer updateQuantity;
+}

--- a/src/main/java/com/zerobase/everycampingbackend/cart/domain/form/UpdateQuantityForm.java
+++ b/src/main/java/com/zerobase/everycampingbackend/cart/domain/form/UpdateQuantityForm.java
@@ -13,9 +13,9 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class UpdateQuantityForm {
 
-  @NotNull
-  Long customerId;
+    @NotNull
+    Long customerId;
 
-  @Min(1)
-  Integer updateQuantity;
+    @Min(1)
+    Integer updateQuantity;
 }

--- a/src/main/java/com/zerobase/everycampingbackend/cart/domain/repository/CartRepository.java
+++ b/src/main/java/com/zerobase/everycampingbackend/cart/domain/repository/CartRepository.java
@@ -3,10 +3,14 @@ package com.zerobase.everycampingbackend.cart.domain.repository;
 import com.zerobase.everycampingbackend.cart.domain.entity.CartProduct;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.EntityGraph.EntityGraphType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CartRepository extends JpaRepository<CartProduct, Long> {
+
+  @EntityGraph(attributePaths = {"product"}, type = EntityGraphType.LOAD)
   Page<CartProduct> findAllByCustomerId(Long CustomerId, Pageable pageable);
 }

--- a/src/main/java/com/zerobase/everycampingbackend/cart/domain/repository/CartRepository.java
+++ b/src/main/java/com/zerobase/everycampingbackend/cart/domain/repository/CartRepository.java
@@ -1,6 +1,7 @@
 package com.zerobase.everycampingbackend.cart.domain.repository;
 
 import com.zerobase.everycampingbackend.cart.domain.entity.CartProduct;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
@@ -12,5 +13,7 @@ import org.springframework.stereotype.Repository;
 public interface CartRepository extends JpaRepository<CartProduct, Long> {
 
   @EntityGraph(attributePaths = {"product"}, type = EntityGraphType.LOAD)
-  Page<CartProduct> findAllByCustomerId(Long CustomerId, Pageable pageable);
+  Page<CartProduct> findAllByCustomerId(Long customerId, Pageable pageable);
+
+  Optional<CartProduct> findByCustomerIdAndProductId(Long customerId, Long productId);
 }

--- a/src/main/java/com/zerobase/everycampingbackend/cart/domain/repository/CartRepository.java
+++ b/src/main/java/com/zerobase/everycampingbackend/cart/domain/repository/CartRepository.java
@@ -1,12 +1,12 @@
 package com.zerobase.everycampingbackend.cart.domain.repository;
 
-import com.zerobase.everycampingbackend.cart.domain.entity.Cart;
+import com.zerobase.everycampingbackend.cart.domain.entity.CartProduct;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface CartRepository extends JpaRepository<Cart, Long> {
-  Page<Cart> findAllByCustomerId(Long CustomerId, Pageable pageable);
+public interface CartRepository extends JpaRepository<CartProduct, Long> {
+  Page<CartProduct> findAllByCustomerId(Long CustomerId, Pageable pageable);
 }

--- a/src/main/java/com/zerobase/everycampingbackend/cart/domain/repository/CartRepository.java
+++ b/src/main/java/com/zerobase/everycampingbackend/cart/domain/repository/CartRepository.java
@@ -12,8 +12,8 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface CartRepository extends JpaRepository<CartProduct, Long> {
 
-  @EntityGraph(attributePaths = {"product"}, type = EntityGraphType.LOAD)
-  Page<CartProduct> findAllByCustomerId(Long customerId, Pageable pageable);
+    @EntityGraph(attributePaths = {"product"}, type = EntityGraphType.LOAD)
+    Page<CartProduct> findAllByCustomerId(Long customerId, Pageable pageable);
 
-  Optional<CartProduct> findByCustomerIdAndProductId(Long customerId, Long productId);
+    Optional<CartProduct> findByCustomerIdAndProductId(Long customerId, Long productId);
 }

--- a/src/main/java/com/zerobase/everycampingbackend/cart/service/CartService.java
+++ b/src/main/java/com/zerobase/everycampingbackend/cart/service/CartService.java
@@ -3,6 +3,7 @@ package com.zerobase.everycampingbackend.cart.service;
 import com.zerobase.everycampingbackend.cart.domain.dto.CartProductDto;
 import com.zerobase.everycampingbackend.cart.domain.entity.CartProduct;
 import com.zerobase.everycampingbackend.cart.domain.form.CreateCartForm;
+import com.zerobase.everycampingbackend.cart.domain.form.UpdateQuantityForm;
 import com.zerobase.everycampingbackend.cart.domain.repository.CartRepository;
 import com.zerobase.everycampingbackend.common.exception.CustomException;
 import com.zerobase.everycampingbackend.common.exception.ErrorCode;
@@ -13,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -22,6 +24,7 @@ public class CartService {
   private final ProductService productService;
   private final CartRepository cartRepository;
 
+  @Transactional
   public void createCart(CreateCartForm form, Long productId) {
 
     //로그인한 Customer 관련 로직 추가 예정
@@ -38,6 +41,7 @@ public class CartService {
   /**
    * 재고 부족 시 주문가능한 최대 수량을 장바구니에 저장하고 response에 담아 준다.
    */
+  @Transactional
   public Page<CartProductDto> getCartProductList(Long customerId, Pageable pageable) {
 
     //로그인한 Customer 관련 로직 추가 예정
@@ -53,6 +57,22 @@ public class CartService {
     cartProduct.setQuantity(cartProduct.getProduct().getStock());
     cartRepository.save(cartProduct);
     return CartProductDto.of(cartProduct, true);
+  }
+
+  @Transactional
+  public void updateQuantity(Long productId, UpdateQuantityForm updateQuantityForm) {
+    //로그인한 Customer 관련 로직 추가 예정
+
+    CartProduct cartProduct = cartRepository.findByCustomerIdAndProductId(
+            updateQuantityForm.getCustomerId(), productId)
+        .orElseThrow(() -> new CustomException(ErrorCode.CART_PRODUCT_NOT_FOUND));
+
+    if (cartProduct.getProduct().getStock() < updateQuantityForm.getUpdateQuantity()) {
+      throw new CustomException(ErrorCode.PRODUCT_NOT_ENOUGH_STOCK);
+    }
+
+    cartProduct.setQuantity(updateQuantityForm.getUpdateQuantity());
+    cartRepository.save(cartProduct);
   }
 
 }

--- a/src/main/java/com/zerobase/everycampingbackend/cart/service/CartService.java
+++ b/src/main/java/com/zerobase/everycampingbackend/cart/service/CartService.java
@@ -75,4 +75,13 @@ public class CartService {
     cartRepository.save(cartProduct);
   }
 
+  @Transactional
+  public void deleteCartProduct(Long productId, Long customerId) {
+    //로그인한 Customer 관련 로직 추가 예정
+
+    CartProduct cartProduct = cartRepository.findByCustomerIdAndProductId(customerId, productId)
+        .orElseThrow(() -> new CustomException(ErrorCode.CART_PRODUCT_NOT_FOUND));
+
+    cartRepository.delete(cartProduct);
+  }
 }

--- a/src/main/java/com/zerobase/everycampingbackend/cart/service/CartService.java
+++ b/src/main/java/com/zerobase/everycampingbackend/cart/service/CartService.java
@@ -20,68 +20,70 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class CartService {
 
-  private final CustomerService customerService;
-  private final ProductService productService;
-  private final CartRepository cartRepository;
+    private final CustomerService customerService;
+    private final ProductService productService;
+    private final CartRepository cartRepository;
 
-  @Transactional
-  public void createCart(CreateCartForm form, Long productId) {
+    @Transactional
+    public void createCart(CreateCartForm form, Long productId) {
 
-    //로그인한 Customer 관련 로직 추가 예정
+        //로그인한 Customer 관련 로직 추가 예정
 
-    Product product = productService.getProductById(productId);
-    if (product.getStock() < form.getQuantity()) {
-      throw new CustomException(ErrorCode.PRODUCT_NOT_ENOUGH_STOCK);
+        Product product = productService.getProductById(productId);
+        if (product.getStock() < form.getQuantity()) {
+            throw new CustomException(ErrorCode.PRODUCT_NOT_ENOUGH_STOCK);
+        }
+
+        cartRepository.save(
+            CartProduct.of(product, customerService.getCustomerById((form.getCustomerId())),
+                form.getQuantity()));
     }
 
-    cartRepository.save(CartProduct.of(product, customerService.getCustomerById((form.getCustomerId())),
-        form.getQuantity()));
-  }
+    /**
+     * 재고 부족 시 주문가능한 최대 수량을 장바구니에 저장하고 response에 담아 준다.
+     */
+    @Transactional
+    public Page<CartProductDto> getCartProductList(Long customerId, Pageable pageable) {
 
-  /**
-   * 재고 부족 시 주문가능한 최대 수량을 장바구니에 저장하고 response에 담아 준다.
-   */
-  @Transactional
-  public Page<CartProductDto> getCartProductList(Long customerId, Pageable pageable) {
+        //로그인한 Customer 관련 로직 추가 예정
 
-    //로그인한 Customer 관련 로직 추가 예정
+        Page<CartProduct> cartProductList = cartRepository.findAllByCustomerId(customerId,
+            pageable);
 
-    Page<CartProduct> cartProductList = cartRepository.findAllByCustomerId(customerId, pageable);
-
-    return cartProductList.map(
-        m -> m.getQuantity() > m.getProduct().getStock() ? handlingOutOfStock(m) :
-            CartProductDto.of(m, false));
-  }
-
-  private CartProductDto handlingOutOfStock(CartProduct cartProduct) {
-    cartProduct.setQuantity(cartProduct.getProduct().getStock());
-    cartRepository.save(cartProduct);
-    return CartProductDto.of(cartProduct, true);
-  }
-
-  @Transactional
-  public void updateQuantity(Long productId, UpdateQuantityForm updateQuantityForm) {
-    //로그인한 Customer 관련 로직 추가 예정
-
-    CartProduct cartProduct = cartRepository.findByCustomerIdAndProductId(
-            updateQuantityForm.getCustomerId(), productId)
-        .orElseThrow(() -> new CustomException(ErrorCode.CART_PRODUCT_NOT_FOUND));
-
-    if (cartProduct.getProduct().getStock() < updateQuantityForm.getUpdateQuantity()) {
-      throw new CustomException(ErrorCode.PRODUCT_NOT_ENOUGH_STOCK);
+        return cartProductList.map(
+            m -> m.getQuantity() > m.getProduct().getStock() ? handlingOutOfStock(m) :
+                CartProductDto.of(m, false));
     }
 
-    cartProduct.setQuantity(updateQuantityForm.getUpdateQuantity());
-    cartRepository.save(cartProduct);
-  }
+    private CartProductDto handlingOutOfStock(CartProduct cartProduct) {
+        cartProduct.setQuantity(cartProduct.getProduct().getStock());
+        cartRepository.save(cartProduct);
+        return CartProductDto.of(cartProduct, true);
+    }
 
-  @Transactional
-  public void deleteCartProduct(Long productId, Long customerId) {
-    //로그인한 Customer 관련 로직 추가 예정
+    @Transactional
+    public void updateQuantity(Long productId, UpdateQuantityForm updateQuantityForm) {
+        //로그인한 Customer 관련 로직 추가 예정
 
-    CartProduct cartProduct = cartRepository.findByCustomerIdAndProductId(customerId, productId)
-        .orElseThrow(() -> new CustomException(ErrorCode.CART_PRODUCT_NOT_FOUND));
+        CartProduct cartProduct = cartRepository.findByCustomerIdAndProductId(
+                updateQuantityForm.getCustomerId(), productId)
+            .orElseThrow(() -> new CustomException(ErrorCode.CART_PRODUCT_NOT_FOUND));
 
-    cartRepository.delete(cartProduct);
-  }
+        if (cartProduct.getProduct().getStock() < updateQuantityForm.getUpdateQuantity()) {
+            throw new CustomException(ErrorCode.PRODUCT_NOT_ENOUGH_STOCK);
+        }
+
+        cartProduct.setQuantity(updateQuantityForm.getUpdateQuantity());
+        cartRepository.save(cartProduct);
+    }
+
+    @Transactional
+    public void deleteCartProduct(Long productId, Long customerId) {
+        //로그인한 Customer 관련 로직 추가 예정
+
+        CartProduct cartProduct = cartRepository.findByCustomerIdAndProductId(customerId, productId)
+            .orElseThrow(() -> new CustomException(ErrorCode.CART_PRODUCT_NOT_FOUND));
+
+        cartRepository.delete(cartProduct);
+    }
 }

--- a/src/main/java/com/zerobase/everycampingbackend/common/exception/ErrorCode.java
+++ b/src/main/java/com/zerobase/everycampingbackend/common/exception/ErrorCode.java
@@ -12,6 +12,7 @@ public enum ErrorCode {
   UNKNOWN_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 예외가 발생했습니다."),
   ARGUMENT_NOT_VALID_EXCEPTION(HttpStatus.BAD_REQUEST, "필드 값이 올바르지 않습니다."),
 
+  CART_PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "장바구니에 들어있지 않은 상품입니다."),
   ORDER_AMOUNT_UNDER_1000(HttpStatus.BAD_REQUEST, "1000원 이하로는 주문할 수 없습니다."),
 
 

--- a/src/test/java/com/zerobase/everycampingbackend/cart/service/CartServiceTest.java
+++ b/src/test/java/com/zerobase/everycampingbackend/cart/service/CartServiceTest.java
@@ -1,6 +1,7 @@
 package com.zerobase.everycampingbackend.cart.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.zerobase.everycampingbackend.cart.domain.dto.CartProductDto;
@@ -191,7 +192,32 @@ class CartServiceTest {
     });
 
     //then
-    assertEquals(ex.getErrorCode(), ErrorCode.PRODUCT_NOT_ENOUGH_STOCK);
+    assertEquals(ErrorCode.PRODUCT_NOT_ENOUGH_STOCK, ex.getErrorCode());
+  }
+
+  @Test
+  @DisplayName("장바구니 물품 삭제 성공")
+  @Transactional
+  void deleteCartProductSuccess() throws Exception {
+
+    //given
+    //유저 세팅
+    Long customerId = createCustomer("ksj2083@naver.com");
+
+    //상품 세팅
+    Long productId1 = createProduct("텐트1", 5, ProductCategory.TENT);
+
+    //장바구니에 넣기
+    addToCart(customerId, productId1, 3);
+
+    //when
+    cartService.deleteCartProduct(productId1, customerId);
+
+    //then
+    Optional<CartProduct> optionalCartProduct = cartRepository.findByCustomerIdAndProductId(
+        customerId, productId1);
+
+    assertFalse(optionalCartProduct.isPresent());
   }
 
   private void addToCart(Long customerId, Long productId, Integer quantity) {

--- a/src/test/java/com/zerobase/everycampingbackend/cart/service/CartServiceTest.java
+++ b/src/test/java/com/zerobase/everycampingbackend/cart/service/CartServiceTest.java
@@ -18,6 +18,7 @@ import com.zerobase.everycampingbackend.product.type.ProductCategory;
 import com.zerobase.everycampingbackend.user.domain.entity.Customer;
 import com.zerobase.everycampingbackend.user.domain.repository.CustomerRepository;
 import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -31,221 +32,221 @@ import org.springframework.transaction.annotation.Transactional;
 @SpringBootTest
 @TestPropertySource(locations = "classpath:application-test.properties")
 @TestInstance(TestInstance.Lifecycle.PER_METHOD)
-@Transactional
 class CartServiceTest {
 
-  @Autowired
-  CartService cartService;
+    @Autowired
+    CartService cartService;
 
-  @Autowired
-  CustomerRepository customerRepository;
+    @Autowired
+    CustomerRepository customerRepository;
 
-  @Autowired
-  ProductRepository productRepository;
+    @Autowired
+    ProductRepository productRepository;
 
-  @Autowired
-  CartRepository cartRepository;
+    @Autowired
+    CartRepository cartRepository;
 
-  @Autowired
-  ProductService productService;
+    @Autowired
+    ProductService productService;
 
-  @Test
-  @DisplayName("장바구니 넣기 실패 - 재고가 부족해서 실패")
-  @Transactional
-  void createCartProductNotEnoughStock() throws Exception {
+    @AfterEach
+    public void clean() {
+        cartRepository.deleteAll();
+        productRepository.deleteAll();
+    }
 
-    //given
-    Long customerId = createCustomer("ksj2083@naver.com");
-    CreateCartForm createCartForm = CreateCartForm.builder()
-        .customerId(customerId)
-        .quantity(6)
-        .build();
+    @Test
+    @DisplayName("장바구니 넣기 실패 - 재고가 부족해서 실패")
+    void createCartProductNotEnoughStock() throws Exception {
 
-    Long productId = createProduct("잡템", 5, ProductCategory.TENT);
+        //given
+        Long customerId = createCustomer("ksj2083@naver.com");
+        CreateCartForm createCartForm = CreateCartForm.builder()
+            .customerId(customerId)
+            .quantity(6)
+            .build();
 
-    //when
-    CustomException ex = (CustomException)assertThrows(RuntimeException.class, () -> {
-      cartService.createCart(createCartForm, productId);
-    });
+        Long productId = createProduct("잡템", 5, ProductCategory.TENT);
 
-    //then
-    assertEquals(ex.getErrorCode(), ErrorCode.PRODUCT_NOT_ENOUGH_STOCK);
-  }
+        //when
+        CustomException ex = (CustomException) assertThrows(RuntimeException.class, () -> {
+            cartService.createCart(createCartForm, productId);
+        });
 
-  @Test
-  @DisplayName("장바구니 넣기 성공")
-  @Transactional
-  void createCartSuccess() throws Exception {
+        //then
+        assertEquals(ex.getErrorCode(), ErrorCode.PRODUCT_NOT_ENOUGH_STOCK);
+    }
 
-    //given
-    Long customerId = createCustomer("ksj2083@naver.com");
-    CreateCartForm createCartForm = CreateCartForm.builder()
-        .customerId(customerId)
-        .quantity(5)
-        .build();
+    @Test
+    @DisplayName("장바구니 넣기 성공")
+    void createCartSuccess() throws Exception {
 
-    Long productId = createProduct("잡템", 5, ProductCategory.TENT);
+        //given
+        Long customerId = createCustomer("ksj2083@naver.com");
+        CreateCartForm createCartForm = CreateCartForm.builder()
+            .customerId(customerId)
+            .quantity(5)
+            .build();
 
-    //when
-    cartService.createCart(createCartForm, productId);
+        Long productId = createProduct("잡템", 5, ProductCategory.TENT);
 
-    //then
-    PageRequest pageRequest = PageRequest.of(0, 5);
-    Page<CartProduct> result = cartRepository.findAllByCustomerId(customerId, pageRequest);
+        //when
+        cartService.createCart(createCartForm, productId);
 
-    assertEquals(result.getContent().get(0).getQuantity(), 5);
-    assertEquals(result.getContent().get(0).getProduct().getName(), "잡템");
-  }
+        //then
+        PageRequest pageRequest = PageRequest.of(0, 5);
+        Page<CartProduct> result = cartRepository.findAllByCustomerId(customerId, pageRequest);
 
-  @Test
-  @DisplayName("장바구니 조회 성공")
-  @Transactional
-  void getCartProductSuccess() throws Exception {
+        assertEquals(result.getContent().get(0).getQuantity(), 5);
+        assertEquals(result.getContent().get(0).getProduct().getName(), "잡템");
+    }
 
-    //given
-    //유저 세팅
-    Long customerId = createCustomer("ksj2083@naver.com");
+    @Test
+    @DisplayName("장바구니 조회 성공")
+    void getCartProductSuccess() throws Exception {
 
-    //상품 세팅
-    Long productId1 = createProduct("텐트1", 5, ProductCategory.TENT);
-    Long productId2 = createProduct("텐트2", 10, ProductCategory.TENT);
+        //given
+        //유저 세팅
+        Long customerId = createCustomer("ksj2083@naver.com");
 
-    //장바구니에 넣기
-    addToCart(customerId, productId1, 3);
-    addToCart(customerId, productId2, 5);
+        //상품 세팅
+        Long productId1 = createProduct("텐트1", 5, ProductCategory.TENT);
+        Long productId2 = createProduct("텐트2", 10, ProductCategory.TENT);
 
-    //when
+        //장바구니에 넣기
+        addToCart(customerId, productId1, 3);
+        addToCart(customerId, productId2, 5);
 
-    //2번 상품은 재고가 1개 남게 되었음
-    Product product = productService.getProductById(productId2);
-    product.setStock(1);
-    productRepository.save(product);
+        //when
 
-    PageRequest pageRequest = PageRequest.of(0, 5);
-    Page<CartProductDto> cartProductPage = cartService.getCartProductList(customerId, pageRequest);
+        //2번 상품은 재고가 1개 남게 되었음
+        Product product = productService.getProductById(productId2);
+        product.setStock(1);
+        productRepository.save(product);
 
-    //then
-    CartProductDto dto1 = cartProductPage.getContent().get(0);
-    CartProductDto dto2 = cartProductPage.getContent().get(1);
+        PageRequest pageRequest = PageRequest.of(0, 5);
+        Page<CartProductDto> cartProductPage = cartService.getCartProductList(customerId,
+            pageRequest);
 
-    assertEquals(productId1, dto1.getProductId());
-    assertEquals(3, dto1.getQuantity());
-    assertEquals(false, dto1.getIsQuantityChanged());
+        //then
+        CartProductDto dto1 = cartProductPage.getContent().get(0);
+        CartProductDto dto2 = cartProductPage.getContent().get(1);
 
-    assertEquals(productId2, dto2.getProductId());
-    assertEquals(1, dto2.getQuantity());
-    assertEquals(true, dto2.getIsQuantityChanged());
+        assertEquals(productId1, dto1.getProductId());
+        assertEquals(3, dto1.getQuantity());
+        assertEquals(false, dto1.getIsQuantityChanged());
 
-  }
+        assertEquals(productId2, dto2.getProductId());
+        assertEquals(1, dto2.getQuantity());
+        assertEquals(true, dto2.getIsQuantityChanged());
 
-  @Test
-  @DisplayName("장바구니 수량 변경 성공")
-  @Transactional
-  void updateQuantitySuccess() throws Exception {
+    }
 
-    //given
-    //유저 세팅
-    Long customerId = createCustomer("ksj2083@naver.com");
+    @Test
+    @DisplayName("장바구니 수량 변경 성공")
+    void updateQuantitySuccess() throws Exception {
 
-    //상품 세팅
-    Long productId1 = createProduct("텐트1", 5, ProductCategory.TENT);
+        //given
+        //유저 세팅
+        Long customerId = createCustomer("ksj2083@naver.com");
 
-    //장바구니에 넣기
-    addToCart(customerId, productId1, 3);
+        //상품 세팅
+        Long productId1 = createProduct("텐트1", 5, ProductCategory.TENT);
 
-    //when
-    cartService.updateQuantity(customerId,
-        UpdateQuantityForm.builder().
-                      customerId(customerId)
-                      .updateQuantity(4)
-                      .build());
+        //장바구니에 넣기
+        addToCart(customerId, productId1, 3);
 
-    //then
-    CartProduct cartProduct = cartRepository.findByCustomerIdAndProductId(
-        customerId, productId1).orElseThrow();
+        //when
+        cartService.updateQuantity(customerId,
+            UpdateQuantityForm.builder().
+                customerId(customerId)
+                .updateQuantity(4)
+                .build());
 
-    assertEquals(4, cartProduct.getQuantity());
-  }
+        //then
+        CartProduct cartProduct = cartRepository.findByCustomerIdAndProductId(
+            customerId, productId1).orElseThrow();
 
-  @Test
-  @DisplayName("장바구니 수량 변경 실패 - 재고가 부족해서 실패")
-  @Transactional
-  void updateQuantityNotEnoughStock() throws Exception {
+        assertEquals(4, cartProduct.getQuantity());
+    }
 
-    //given
-    //유저 세팅
-    Long customerId = createCustomer("ksj2083@naver.com");
+    @Test
+    @DisplayName("장바구니 수량 변경 실패 - 재고가 부족해서 실패")
+    void updateQuantityNotEnoughStock() throws Exception {
 
-    //상품 세팅
-    Long productId1 = createProduct("텐트1", 5, ProductCategory.TENT);
+        //given
+        //유저 세팅
+        Long customerId = createCustomer("ksj2083@naver.com");
 
-    //장바구니에 넣기
-    addToCart(customerId, productId1, 3);
+        //상품 세팅
+        Long productId1 = createProduct("텐트1", 5, ProductCategory.TENT);
 
-    //when
-    CustomException ex = (CustomException) assertThrows(RuntimeException.class, () -> {
-      cartService.updateQuantity(customerId,
-          UpdateQuantityForm.builder().
-              customerId(customerId)
-              .updateQuantity(6)
-              .build());
-    });
+        //장바구니에 넣기
+        addToCart(customerId, productId1, 3);
 
-    //then
-    assertEquals(ErrorCode.PRODUCT_NOT_ENOUGH_STOCK, ex.getErrorCode());
-  }
+        //when
+        CustomException ex = (CustomException) assertThrows(RuntimeException.class, () -> {
+            cartService.updateQuantity(productId1,
+                UpdateQuantityForm.builder().
+                    customerId(customerId)
+                    .updateQuantity(6)
+                    .build());
+        });
 
-  @Test
-  @DisplayName("장바구니 물품 삭제 성공")
-  @Transactional
-  void deleteCartProductSuccess() throws Exception {
+        //then
+        assertEquals(ErrorCode.PRODUCT_NOT_ENOUGH_STOCK, ex.getErrorCode());
+    }
 
-    //given
-    //유저 세팅
-    Long customerId = createCustomer("ksj2083@naver.com");
+    @Test
+    @DisplayName("장바구니 물품 삭제 성공")
+    void deleteCartProductSuccess() throws Exception {
 
-    //상품 세팅
-    Long productId1 = createProduct("텐트1", 5, ProductCategory.TENT);
+        //given
+        //유저 세팅
+        Long customerId = createCustomer("ksj2083@naver.com");
 
-    //장바구니에 넣기
-    addToCart(customerId, productId1, 3);
+        //상품 세팅
+        Long productId1 = createProduct("텐트1", 5, ProductCategory.TENT);
 
-    //when
-    cartService.deleteCartProduct(productId1, customerId);
+        //장바구니에 넣기
+        addToCart(customerId, productId1, 3);
 
-    //then
-    Optional<CartProduct> optionalCartProduct = cartRepository.findByCustomerIdAndProductId(
-        customerId, productId1);
+        //when
+        cartService.deleteCartProduct(productId1, customerId);
 
-    assertFalse(optionalCartProduct.isPresent());
-  }
+        //then
+        Optional<CartProduct> optionalCartProduct = cartRepository.findByCustomerIdAndProductId(
+            customerId, productId1);
 
-  private void addToCart(Long customerId, Long productId, Integer quantity) {
-    cartService.createCart(CreateCartForm.builder()
-        .customerId(customerId)
-        .quantity(quantity)
-        .build(), productId);
-  }
+        assertFalse(optionalCartProduct.isPresent());
+    }
+
+    private void addToCart(Long customerId, Long productId, Integer quantity) {
+        cartService.createCart(CreateCartForm.builder()
+            .customerId(customerId)
+            .quantity(quantity)
+            .build(), productId);
+    }
 
 
-  private Long createProduct(String name, int stock, ProductCategory category) {
-    Product product = Product.builder()
-        .name(name)
-        .category(category)
-        .stock(stock)
-        .build();
+    private Long createProduct(String name, int stock, ProductCategory category) {
+        Product product = Product.builder()
+            .name(name)
+            .category(category)
+            .stock(stock)
+            .build();
 
-    Product saved = productRepository.save(product);
-    return saved.getId();
-  }
+        Product saved = productRepository.save(product);
+        return saved.getId();
+    }
 
-  private Long createCustomer(String email){
-    Customer customer = Customer.builder()
-        .email(email)
-        .build();
+    private Long createCustomer(String email) {
+        Customer customer = Customer.builder()
+            .email(email)
+            .build();
 
-    Customer saved = customerRepository.save(customer);
-    return saved.getId();
-  }
+        Customer saved = customerRepository.save(customer);
+        return saved.getId();
+    }
 
 }


### PR DESCRIPTION
Background
---
장바구니 조회, 개수 수정, 삭제를 구현하였습니다. 
조회의 경우 매번 조회할 때마다 장바구니에 등록된 수량과 실제 재고를 비교하여, 등록된 수량이 더 적을 경우 DB에 기록된 값을 주문 가능한 수량으로 변경하고 response에 변경 유무를 알려주는 로직이 실행됩니다.
수정 삭제의 경우 특이 사항 없습니다.

Change
---
장바구니 조회, 개수 수정, 삭제를 구현하였습니다. 
또한 엔티티명이 변경되었습니다.
기존 : Cart -> 현재 : CartProduct
해당 테이블은 엄밀히 따지면 장바구니 자체가 아니라 장바구니에 담긴 상품을 의미하기 때문에 표현을 명확하게 하기 위해 변경하였습니다.
 


Test
---
단위테스트 작성 완료하였습니다.
#21 에 따라 테스트 트랜잭션 제거하였습니다.

Analatics
---
조회에서 N+1문제가 발생하였고, fetch join을 통해 문제를 해결하였습니다.
n+1 문제 관련 포스팅을 작성하였습니다.
[n+1 관련 포스팅](https://ksj2083.tistory.com/22)

Discuss
---
저는 현재 등록, 수정, 삭제 성공 시 Response로 httpStatus.ok 만 담아서 보내고 있습니다.
그런데 다른 분이 작성한 코드와 차이가 있는 것 같아서 회의하여 통일해야 할 것 같습니다.