### PR TITLE
Apply-UserDetails-To-Controller (Closes #5)

### DIFF
--- a/src/main/java/com/zerobase/everycampingbackend/common/config/SecurityConfiguration.java
+++ b/src/main/java/com/zerobase/everycampingbackend/common/config/SecurityConfiguration.java
@@ -3,9 +3,7 @@ package com.zerobase.everycampingbackend.common.config;
 import com.zerobase.everycampingbackend.common.auth.filter.JwtAuthFilter;
 import com.zerobase.everycampingbackend.common.auth.model.UserType;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -37,12 +35,6 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
         , "/sellers/reissue"
         , "/test/**"
     };
-
-    @Bean
-    @Override
-    protected AuthenticationManager authenticationManager() throws Exception {
-        return super.authenticationManager();
-    }
 
     @Override
     public void configure(WebSecurity web) {

--- a/src/main/java/com/zerobase/everycampingbackend/product/controller/ProductManageController.java
+++ b/src/main/java/com/zerobase/everycampingbackend/product/controller/ProductManageController.java
@@ -4,6 +4,7 @@ import com.zerobase.everycampingbackend.product.domain.dto.ProductDetailDto;
 import com.zerobase.everycampingbackend.product.domain.dto.ProductDto;
 import com.zerobase.everycampingbackend.product.domain.form.ProductManageForm;
 import com.zerobase.everycampingbackend.product.service.ProductManageService;
+import com.zerobase.everycampingbackend.user.domain.entity.Seller;
 import java.io.IOException;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -11,7 +12,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -29,37 +29,37 @@ public class ProductManageController {
     private final ProductManageService productManageService;
 
     @PostMapping
-    public ResponseEntity<Boolean> addProduct(@AuthenticationPrincipal UserDetails user,
+    public ResponseEntity<?> addProduct(@AuthenticationPrincipal Seller seller,
         @RequestBody @Valid ProductManageForm form) throws IOException {
-        productManageService.addProduct(form);
-        return ResponseEntity.ok(true);
+        productManageService.addProduct(seller, form);
+        return ResponseEntity.ok().build();
     }
 
     @PutMapping("/{productId}")
-    public ResponseEntity<Boolean> updateProduct(@AuthenticationPrincipal UserDetails user,
+    public ResponseEntity<?> updateProduct(@AuthenticationPrincipal Seller seller,
         @PathVariable Long productId,
         @RequestBody @Valid ProductManageForm form) throws IOException {
-        productManageService.updateProduct(productId, form);
-        return ResponseEntity.ok(true);
+        productManageService.updateProduct(seller, productId, form);
+        return ResponseEntity.ok().build();
     }
 
     @DeleteMapping("/{productId}")
-    public ResponseEntity<Boolean> deleteProduct(@AuthenticationPrincipal UserDetails user,
+    public ResponseEntity<?> deleteProduct(@AuthenticationPrincipal Seller seller,
         @PathVariable Long productId) {
-        productManageService.deleteProduct(productId);
-        return ResponseEntity.ok(true);
+        productManageService.deleteProduct(seller, productId);
+        return ResponseEntity.ok().build();
     }
 
     @GetMapping("/{productId}")
     public ResponseEntity<ProductDetailDto> getProductDetail(
-        @AuthenticationPrincipal UserDetails user,
+        @AuthenticationPrincipal Seller seller,
         @PathVariable Long productId) {
-        return ResponseEntity.ok(productManageService.getProductDetail(productId));
+        return ResponseEntity.ok(productManageService.getProductDetail(seller, productId));
     }
 
     @GetMapping
     public ResponseEntity<Page<ProductDto>> getProductPage(
-        @AuthenticationPrincipal UserDetails user, Pageable pageable) {
-        return ResponseEntity.ok(productManageService.getProductPage(pageable));
+        @AuthenticationPrincipal Seller seller, Pageable pageable) {
+        return ResponseEntity.ok(productManageService.getProductPage(seller, pageable));
     }
 }

--- a/src/main/java/com/zerobase/everycampingbackend/product/domain/entity/Product.java
+++ b/src/main/java/com/zerobase/everycampingbackend/product/domain/entity/Product.java
@@ -53,9 +53,10 @@ public class Product extends BaseEntity {
     private int reviewCount;
     private int totalScore;
 
-    public static Product of(ProductManageForm form, S3Path imagePath, S3Path detailImagePath){
+    public static Product of(ProductManageForm form, Seller seller, S3Path imagePath, S3Path detailImagePath){
         return Product.builder()
             .name(form.getName())
+            .seller(seller)
             .category(form.getCategory())
             .price(form.getPrice())
             .onSale(form.getOnSale())

--- a/src/main/java/com/zerobase/everycampingbackend/product/domain/repository/ProductRepository.java
+++ b/src/main/java/com/zerobase/everycampingbackend/product/domain/repository/ProductRepository.java
@@ -1,6 +1,7 @@
 package com.zerobase.everycampingbackend.product.domain.repository;
 
 import com.zerobase.everycampingbackend.product.domain.entity.Product;
+import com.zerobase.everycampingbackend.user.domain.entity.Seller;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -8,5 +9,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ProductRepository extends JpaRepository<Product, Long>, ProductRepositoryCustom {
-    Page<Product> findAll(Pageable pageable);
+    Page<Product> findAllBySeller(Seller seller, Pageable pageable);
 }

--- a/src/main/java/com/zerobase/everycampingbackend/review/controller/ReviewController.java
+++ b/src/main/java/com/zerobase/everycampingbackend/review/controller/ReviewController.java
@@ -3,11 +3,12 @@ package com.zerobase.everycampingbackend.review.controller;
 import com.zerobase.everycampingbackend.review.domain.dto.ReviewDto;
 import com.zerobase.everycampingbackend.review.domain.form.ReviewForm;
 import com.zerobase.everycampingbackend.review.service.ReviewService;
+import com.zerobase.everycampingbackend.user.domain.entity.Customer;
 import java.io.IOException;
-import java.security.Principal;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -25,26 +26,25 @@ public class ReviewController {
     private final ReviewService reviewService;
 
     @PostMapping
-    public ResponseEntity<Boolean> writeReview(Principal principal,
-        @RequestBody Long customerId,
+    public ResponseEntity<?> writeReview(@AuthenticationPrincipal Customer customer,
         @RequestBody Long productId,
         @RequestBody ReviewForm form)
         throws IOException {
-        reviewService.writeReview(principal.getName(), customerId, productId, form);
-        return ResponseEntity.ok(true);
+        reviewService.writeReview(customer, productId, form);
+        return ResponseEntity.ok().build();
     }
 
     @PutMapping("/{reviewId}")
-    public ResponseEntity<Boolean> editReview(Principal principal,
+    public ResponseEntity<?> editReview(@AuthenticationPrincipal Customer customer,
         @PathVariable Long reviewId, @RequestBody ReviewForm form) throws IOException {
-        reviewService.editReview(principal.getName(), reviewId, form);
-        return ResponseEntity.ok(true);
+        reviewService.editReview(customer, reviewId, form);
+        return ResponseEntity.ok().build();
     }
 
     @DeleteMapping("/{reviewId}")
-    public ResponseEntity<Boolean> deleteReview(Principal principal, @PathVariable Long reviewId) {
-        reviewService.deleteReview(principal.getName(), reviewId);
-        return ResponseEntity.ok(true);
+    public ResponseEntity<?> deleteReview(@AuthenticationPrincipal Customer customer, @PathVariable Long reviewId) {
+        reviewService.deleteReview(customer, reviewId);
+        return ResponseEntity.ok().build();
     }
 
     @GetMapping("/{reviewId}")

--- a/src/main/java/com/zerobase/everycampingbackend/review/service/ReviewService.java
+++ b/src/main/java/com/zerobase/everycampingbackend/review/service/ReviewService.java
@@ -32,12 +32,12 @@ public class ReviewService {
     private final StaticImageService staticImageService;
 
     @Transactional
-    public void writeReview(String userEmail, Long customerId, Long productId, ReviewForm form)
+    public void writeReview(Customer customer, Long productId, ReviewForm form)
         throws IOException {
-        log.info(userEmail + " -> 리뷰 작성 시도");
+        log.info(customer.getEmail() + " -> 리뷰 작성 시도");
 
-        Customer customer = customerService.getCustomerById(customerId);
-        if (!customer.getEmail().equals(userEmail)) {
+        Customer validCustomer = customerService.getCustomerById(customer.getId());
+        if (!validCustomer.getEmail().equals(customer.getEmail())) {
             throw new CustomException(ErrorCode.REVIEW_WRITER_NOT_QUALIFIED);
         }
 
@@ -49,15 +49,15 @@ public class ReviewService {
         reviewRepository.save(Review.of(form, customer, product, s3Path));
         productService.addReview(product, form.getScore());
 
-        log.info(userEmail + " -> 리뷰 작성 완료");
+        log.info(customer.getEmail() + " -> 리뷰 작성 완료");
     }
 
     @Transactional
-    public void editReview(String userEmail, Long reviewId, ReviewForm form) throws IOException{
-        log.info(userEmail + " -> 리뷰 수정 시도");
+    public void editReview(Customer customer, Long reviewId, ReviewForm form) throws IOException{
+        log.info(customer.getEmail() + " -> 리뷰 수정 시도");
 
         Review review = getReviewById(reviewId);
-        if (!review.getCustomer().getEmail().equals(userEmail)) {
+        if (!review.getCustomer().getEmail().equals(customer.getEmail())) {
             throw new CustomException(ErrorCode.REVIEW_EDITOR_NOT_MATCHED);
         }
 
@@ -69,15 +69,15 @@ public class ReviewService {
 
         productService.updateReview(review.getProduct(), review.getScore() - oldScore);
 
-        log.info(userEmail + " -> 리뷰 수정 완료");
+        log.info(customer.getEmail() + " -> 리뷰 수정 완료");
     }
 
     @Transactional
-    public void deleteReview(String userEmail, Long reviewId) {
-        log.info(userEmail + " -> 리뷰 삭제 시도");
+    public void deleteReview(Customer customer, Long reviewId) {
+        log.info(customer.getEmail() + " -> 리뷰 삭제 시도");
 
         Review review = getReviewById(reviewId);
-        if (!review.getCustomer().getEmail().equals(userEmail)) {
+        if (!review.getCustomer().getEmail().equals(customer.getEmail())) {
             throw new CustomException(ErrorCode.REVIEW_EDITOR_NOT_MATCHED);
         }
 
@@ -85,7 +85,7 @@ public class ReviewService {
         staticImageService.deleteImage(review.getImagePath());
         productService.deleteReview(review.getProduct(), review.getScore());
 
-        log.info(userEmail + " -> 리뷰 삭제 완료");
+        log.info(customer.getEmail() + " -> 리뷰 삭제 완료");
     }
 
     public ReviewDto getReviewDetail(Long reviewId) {

--- a/src/test/java/com/zerobase/everycampingbackend/product/service/ProductServiceTest.java
+++ b/src/test/java/com/zerobase/everycampingbackend/product/service/ProductServiceTest.java
@@ -11,6 +11,8 @@ import com.zerobase.everycampingbackend.product.domain.entity.Product;
 import com.zerobase.everycampingbackend.product.domain.form.ProductSearchForm;
 import com.zerobase.everycampingbackend.product.domain.repository.ProductRepository;
 import com.zerobase.everycampingbackend.product.type.ProductCategory;
+import com.zerobase.everycampingbackend.user.domain.entity.Seller;
+import com.zerobase.everycampingbackend.user.domain.repository.SellerRepository;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -31,29 +33,36 @@ class ProductServiceTest {
 
     @Autowired
     private ProductRepository productRepository;
+    @Autowired
+    private SellerRepository sellerRepository;
 
     @Autowired
     private ProductService productService;
 
+    Seller seller = Seller.builder().nickName("판매자1").build();
     Product product1 = Product.builder()
         .name("상품1")
+        .seller(seller)
         .category(ProductCategory.TENT)
         .tags(List.of("따뜻", "단아"))
         .build();
     Product product2 = Product.builder()
         .name("상품2")
+        .seller(seller)
         .category(ProductCategory.MAT)
         .tags(List.of("따뜻", "우리집"))
         .build();
 
     Product product3 = Product.builder()
         .name("상품3")
+        .seller(seller)
         .category(ProductCategory.TABLE)
         .tags(List.of("쿨", "우리집"))
         .build();
 
     Product product4 = Product.builder()
         .name("텐트임")
+        .seller(seller)
         .category(ProductCategory.TENT)
         .tags(List.of("럭셔리"))
         .build();
@@ -62,6 +71,7 @@ class ProductServiceTest {
 
     @BeforeEach
     void setUp() {
+        sellerRepository.save(seller);
         productRepository.save(product1);
         productRepository.save(product2);
         productRepository.save(product3);

--- a/src/test/java/com/zerobase/everycampingbackend/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/zerobase/everycampingbackend/review/service/ReviewServiceTest.java
@@ -51,8 +51,8 @@ class ReviewServiceTest {
     private ReviewService reviewService;
 
     private final ReviewForm form = new ReviewForm(1, "리뷰", null);
-    private String userEmail = "aaa";
     private final Customer customer = Customer.builder().id(1L).email("aaa").build();
+    private final Customer customer2 = Customer.builder().id(2L).email("bbb").build();
     private final Product product = Product.builder().id(1L).build();
     private final Review review = Review.builder()
         .id(1L)
@@ -76,7 +76,7 @@ class ReviewServiceTest {
         ArgumentCaptor<Review> captor = ArgumentCaptor.forClass(Review.class);
 
         // when
-        reviewService.writeReview(userEmail, 1L, 1L, form);
+        reviewService.writeReview(customer, 1L, form);
 
         // then
         verify(reviewRepository).save(captor.capture());
@@ -92,13 +92,12 @@ class ReviewServiceTest {
     @DisplayName("리뷰 작성 실패 - 로그인 유저와 폼 유저 정보 불일치")
     void fail_writeReview_customerNotMatched(){
         // given
-        userEmail = "eeeee";
         given(customerService.getCustomerById(anyLong()))
             .willReturn(customer);
 
         // when
         CustomException exception = assertThrows(CustomException.class, () ->
-            reviewService.writeReview(userEmail, 1L, 1L, form));
+            reviewService.writeReview(customer2, 1L, form));
 
         // then
         assertEquals(ErrorCode.REVIEW_WRITER_NOT_QUALIFIED, exception.getErrorCode());
@@ -117,7 +116,7 @@ class ReviewServiceTest {
         ArgumentCaptor<Review> captor = ArgumentCaptor.forClass(Review.class);
 
         // when
-        reviewService.editReview(userEmail, 1L, form);
+        reviewService.editReview(customer, 1L, form);
 
         // then
         verify(reviewRepository).save(captor.capture());
@@ -131,13 +130,12 @@ class ReviewServiceTest {
     @DisplayName("리뷰 수정 실패 - 해당 리뷰 없음")
     void fail_editReview_reviewNotFound(){
         // given
-        userEmail = "not-matched-user";
         given(reviewRepository.findById(anyLong()))
             .willReturn(Optional.empty());
 
         // when
         CustomException exception = assertThrows(CustomException.class, () ->
-            reviewService.editReview(userEmail, 1L, form));
+            reviewService.editReview(customer, 1L, form));
 
         // then
         assertEquals(ErrorCode.REVIEW_NOT_FOUND, exception.getErrorCode());
@@ -147,13 +145,12 @@ class ReviewServiceTest {
     @DisplayName("리뷰 수정 실패 - 해당 리뷰 수정 권한 없음")
     void fail_editReview_userNotEditor(){
         // given
-        userEmail = "not-matched-user";
         given(reviewRepository.findById(anyLong()))
             .willReturn(Optional.of(review));
 
         // when
         CustomException exception = assertThrows(CustomException.class, () ->
-            reviewService.editReview(userEmail, 1L, form));
+            reviewService.editReview(customer2, 1L, form));
 
         // then
         assertEquals(ErrorCode.REVIEW_EDITOR_NOT_MATCHED, exception.getErrorCode());
@@ -168,7 +165,7 @@ class ReviewServiceTest {
         ArgumentCaptor<Review> captor = ArgumentCaptor.forClass(Review.class);
 
         // when
-        reviewService.deleteReview(userEmail, 1L);
+        reviewService.deleteReview(customer, 1L);
 
         // then
         verify(reviewRepository).delete(captor.capture());
@@ -183,7 +180,7 @@ class ReviewServiceTest {
 
         // when
         CustomException exception = assertThrows(CustomException.class, () ->
-            reviewService.deleteReview(userEmail, 1L));
+            reviewService.deleteReview(customer, 1L));
 
         // then
         assertEquals(ErrorCode.REVIEW_NOT_FOUND, exception.getErrorCode());
@@ -193,13 +190,12 @@ class ReviewServiceTest {
     @DisplayName("리뷰 삭제 실패 - 리뷰 삭제 권한 없음")
     void fail_deleteReview_userNotEditor(){
         // given
-        userEmail = "wfqwfqf";
         given(reviewRepository.findById(anyLong()))
             .willReturn(Optional.of(review));
 
         // when
         CustomException exception = assertThrows(CustomException.class, () ->
-            reviewService.deleteReview(userEmail, 1L));
+            reviewService.deleteReview(customer2, 1L));
 
         // then
         assertEquals(ErrorCode.REVIEW_EDITOR_NOT_MATCHED, exception.getErrorCode());


### PR DESCRIPTION
Background
---
임시로 UserDetails 인터페이스로 유저 정보 받던 부분을 구현체로 변경할 필요가 있다.

Change
---
@AuthenticationPrincial 이용해서 각 api마다 접근 가능한 형태의 UserDetails 구현체로 패러미터 주입. 빈 ResponseEntity Raw 타입에서 와일드 카드 사용으로 변경.
UserDetails 받아서 검증하는 방식으로 검증방식 변경.

Test
---
변경 후 서비스단에 대한 테스트 확인 완료.

Analatics
---
SecurityConfiguration을 통해서 각 api에 대한 role 별 접근 제한을 주의깊게 설정 할 필요가 있다.

Discuss
---
Closes #5