### PR TITLE
카트 버그 수정 및 상품 카테고리 종류 추가

### DIFF
--- a/src/main/java/com/zerobase/everycampingbackend/domain/cart/form/AddToCartForm.java
+++ b/src/main/java/com/zerobase/everycampingbackend/domain/cart/form/AddToCartForm.java
@@ -1,0 +1,17 @@
+package com.zerobase.everycampingbackend.domain.cart.form;
+
+import javax.validation.constraints.Min;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AddToCartForm {
+
+    @Min(1)
+    private Integer quantity;
+}

--- a/src/main/java/com/zerobase/everycampingbackend/domain/cart/form/UpdateQuantityForm.java
+++ b/src/main/java/com/zerobase/everycampingbackend/domain/cart/form/UpdateQuantityForm.java
@@ -1,0 +1,17 @@
+package com.zerobase.everycampingbackend.domain.cart.form;
+
+import javax.validation.constraints.Min;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateQuantityForm {
+
+    @Min(1)
+    private Integer updateQuantity;
+}

--- a/src/main/java/com/zerobase/everycampingbackend/domain/cart/service/CartService.java
+++ b/src/main/java/com/zerobase/everycampingbackend/domain/cart/service/CartService.java
@@ -23,7 +23,7 @@ public class CartService {
     private final CartRepository cartRepository;
 
     @Transactional
-    public void createCart(Customer customer, Long productId, Integer quantity) {
+    public void addToCart(Customer customer, Long productId, Integer quantity) {
 
         Optional<CartProduct> cartProduct = cartRepository.findByCustomerIdAndProductId(
             customer.getId(), productId);

--- a/src/main/java/com/zerobase/everycampingbackend/domain/order/form/OrderForm.java
+++ b/src/main/java/com/zerobase/everycampingbackend/domain/order/form/OrderForm.java
@@ -24,7 +24,7 @@ public class OrderForm {
 
         @NotNull
         private Long productId;
-        @Min(0)
+        @Min(1)
         private Integer quantity;
     }
 }

--- a/src/main/java/com/zerobase/everycampingbackend/domain/product/type/ProductCategory.java
+++ b/src/main/java/com/zerobase/everycampingbackend/domain/product/type/ProductCategory.java
@@ -4,5 +4,7 @@ public enum ProductCategory {
     TENT,
     TABLE,
     CHAIR,
-    MAT
+    MAT,
+    COOK,
+    ACCESSORY
 }

--- a/src/main/java/com/zerobase/everycampingbackend/web/controller/CartController.java
+++ b/src/main/java/com/zerobase/everycampingbackend/web/controller/CartController.java
@@ -1,10 +1,11 @@
 package com.zerobase.everycampingbackend.web.controller;
 
 import com.zerobase.everycampingbackend.domain.cart.dto.CartProductDto;
+import com.zerobase.everycampingbackend.domain.cart.form.AddToCartForm;
+import com.zerobase.everycampingbackend.domain.cart.form.UpdateQuantityForm;
 import com.zerobase.everycampingbackend.domain.cart.service.CartService;
 import com.zerobase.everycampingbackend.domain.user.entity.Customer;
 import javax.validation.Valid;
-import javax.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -28,9 +29,9 @@ public class CartController {
 
     @PostMapping("/add/{productId}")
     public ResponseEntity<?> addToCart(@AuthenticationPrincipal Customer customer,
-        @PathVariable Long productId, @RequestBody @Valid @Min(1) Integer quantity) {
+        @PathVariable Long productId, @RequestBody @Valid AddToCartForm form) {
 
-        cartService.addToCart(customer, productId, quantity);
+        cartService.addToCart(customer, productId, form.getQuantity());
         return ResponseEntity.ok().build();
     }
 
@@ -43,9 +44,9 @@ public class CartController {
 
     @PatchMapping("/{productId}")
     public ResponseEntity<?> updateQuantity(@AuthenticationPrincipal Customer customer,
-        @PathVariable Long productId, @RequestBody @Valid @Min(1) Integer updateQuantity) {
+        @PathVariable Long productId, @RequestBody @Valid UpdateQuantityForm form) {
 
-        cartService.updateQuantity(customer, productId, updateQuantity);
+        cartService.updateQuantity(customer, productId, form.getUpdateQuantity());
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/zerobase/everycampingbackend/web/controller/CartController.java
+++ b/src/main/java/com/zerobase/everycampingbackend/web/controller/CartController.java
@@ -27,10 +27,10 @@ public class CartController {
     private final CartService cartService;
 
     @PostMapping("/add/{productId}")
-    public ResponseEntity<?> createCarts(@AuthenticationPrincipal Customer customer,
+    public ResponseEntity<?> addToCart(@AuthenticationPrincipal Customer customer,
         @PathVariable Long productId, @RequestBody @Valid @Min(1) Integer quantity) {
 
-        cartService.createCart(customer, productId, quantity);
+        cartService.addToCart(customer, productId, quantity);
         return ResponseEntity.ok().build();
     }
 

--- a/src/test/java/com/zerobase/everycampingbackend/cart/service/CartServiceTest.java
+++ b/src/test/java/com/zerobase/everycampingbackend/cart/service/CartServiceTest.java
@@ -64,7 +64,7 @@ class CartServiceTest {
 
         //when
         CustomException ex = (CustomException) assertThrows(RuntimeException.class, () -> {
-            cartService.createCart(customer, productId, quantity);
+            cartService.addToCart(customer, productId, quantity);
         });
 
         //then
@@ -85,7 +85,7 @@ class CartServiceTest {
 
         //when
         CustomException ex = (CustomException) assertThrows(RuntimeException.class, () -> {
-            cartService.createCart(customer, productId, quantity);
+            cartService.addToCart(customer, productId, quantity);
         });
 
         //then
@@ -102,7 +102,7 @@ class CartServiceTest {
         Integer quantity = 5;
 
         //when
-        cartService.createCart(customer, productId, quantity);
+        cartService.addToCart(customer, productId, quantity);
 
         //then
         PageRequest pageRequest = PageRequest.of(0, 5);
@@ -228,7 +228,7 @@ class CartServiceTest {
     }
 
     private void addToCart(Customer customer, Long productId, Integer quantity) {
-        cartService.createCart(customer, productId, quantity);
+        cartService.addToCart(customer, productId, quantity);
     }
 
     private Long createProduct(String name, int stock, ProductCategory category) {


### PR DESCRIPTION
Background
---
장바구니 추가, 수정 시 변수가 "개수" 한 개 뿐이라 별도 form 클래스를 만들지 않았다.
그런데 컨트롤러에서 @RequstBody를 받을 때 별도의 form 클래스로 감싸지 않으면 JSON 형식 데이터를 매핑 해주지 않는다!  그래서 수정했다.

Change
---
1. 장바구니 추가, 수정 시 body 데이터를 json 형식으로 받을 수 있도록 수정
2. 명확한 의미 표현을 위해 메소드 명 수정 createCart -> addToCart 
3. 상품 카테고리에 COOK, ACCESSORY 추가

Test
---
단위테스트 이상 없음, POST맨을 통한 API 테스트 이상 없음

교훈
---
단위테스트 위주로 하다보니 api 단위의 테스트를 제대로 못했다.. 그래서 JSON 매핑이 제대로 되는지 테스트가 제대로 안됐던 것 같다. 다음부터는 컨트롤러 단의 테스트도 신경써야 할 것 같다.