### PR TITLE
주문 리팩토링

### DIFF
--- a/src/main/java/com/zerobase/everycampingbackend/common/QueryDslUtil.java
+++ b/src/main/java/com/zerobase/everycampingbackend/common/QueryDslUtil.java
@@ -1,0 +1,15 @@
+package com.zerobase.everycampingbackend.common;
+
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.Expressions;
+
+public class QueryDslUtil {
+
+    public static OrderSpecifier<?> getSortedColumn(Order order, Path<?> parent, String fieldName) {
+        Path<Object> fieldPath = Expressions.path(Object.class, parent, fieldName);
+        return new OrderSpecifier(order, fieldPath);
+    }
+
+}

--- a/src/main/java/com/zerobase/everycampingbackend/domain/order/dto/OrderProductByCustomerDto.java
+++ b/src/main/java/com/zerobase/everycampingbackend/domain/order/dto/OrderProductByCustomerDto.java
@@ -30,6 +30,8 @@ public class OrderProductByCustomerDto {
     private Integer quantity; //주문수량
     private Integer amount; // 총 금액
     private OrderStatus status; //주문 상태
+    private String address; //배송지 주소
+    private String phone; //수령자 전화번호
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
     private LocalDateTime createdAt; // 주문 일자

--- a/src/main/java/com/zerobase/everycampingbackend/domain/order/dto/OrderProductByCustomerDto.java
+++ b/src/main/java/com/zerobase/everycampingbackend/domain/order/dto/OrderProductByCustomerDto.java
@@ -1,6 +1,8 @@
 package com.zerobase.everycampingbackend.domain.order.dto;
 
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.zerobase.everycampingbackend.domain.order.entity.OrderProduct;
 import com.zerobase.everycampingbackend.domain.order.type.OrderStatus;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
@@ -15,21 +17,35 @@ import lombok.ToString;
 @NoArgsConstructor
 @AllArgsConstructor
 public class OrderProductByCustomerDto {
-
     //상품 관련정보
     private Long productId;
-    private String productName;
-    private Integer stockPrice;
-    private String imagePath;
+
+    //스냅샷
+    private String productNameSnapshot; // 주문 시 상품명
+    private Integer stockPriceSnapshot; // 주문 시 개당 가격
+    private String imageUriSnapshot; // 주문 시 상품 이미지 url
 
     //주문 관련정보
     private Long orderProductId;
-    private Integer quantity;
-    private Integer amount;
-    private OrderStatus status;
-    private LocalDateTime createdAt;
+    private Integer quantity; //주문수량
+    private Integer amount; // 총 금액
+    private OrderStatus status; //주문 상태
 
-    //판매자 관련 정보
-    private Long sellerId;
-    private String sellerNickName;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
+    private LocalDateTime createdAt; // 주문 일자
+
+    public static OrderProductByCustomerDto from(OrderProduct orderProduct) {
+
+        return OrderProductByCustomerDto.builder()
+            .productId(orderProduct.getProduct().getId())
+            .productNameSnapshot(orderProduct.getProductNameSnapshot())
+            .stockPriceSnapshot(orderProduct.getStockPriceSnapshot())
+            .imageUriSnapshot(orderProduct.getImageUriSnapshot())
+            .orderProductId(orderProduct.getId())
+            .quantity(orderProduct.getQuantity())
+            .amount(orderProduct.getAmount())
+            .status(orderProduct.getStatus())
+            .createdAt(orderProduct.getCreatedAt())
+            .build();
+    }
 }

--- a/src/main/java/com/zerobase/everycampingbackend/domain/order/dto/OrderProductBySellerDto.java
+++ b/src/main/java/com/zerobase/everycampingbackend/domain/order/dto/OrderProductBySellerDto.java
@@ -1,6 +1,7 @@
 package com.zerobase.everycampingbackend.domain.order.dto;
 
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.zerobase.everycampingbackend.domain.order.type.OrderStatus;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
@@ -16,20 +17,25 @@ import lombok.ToString;
 @AllArgsConstructor
 public class OrderProductBySellerDto {
 
+    //스냅샷
+    private String productNameSnapshot; // 주문 시 상품명
+    private Integer stockPriceSnapshot; // 주문 시 개당 가격
+    private String imageUriSnapshot; // 주문 시 상품 이미지 url
+
     //상품 관련정보
     private Long productId;
-    private String productName;
-    private Integer stockPrice;
-    private String imagePath;
 
     //주문 관련정보
     private Long orderProductId;
-    private Integer quantity;
-    private Integer amount;
-    private OrderStatus status;
-    private LocalDateTime createdAt;
+    private String address; //배송지 주소
+    private String phone; //수령인 전화번호
+    private Integer quantity; //주문수량
+    private Integer amount; // 총 금액(구매자가 지불한 금액)
+    private OrderStatus status; //주문 상태
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
+    private LocalDateTime createdAt; // 주문 일자
 
     //구매자 관련 정보
     private Long customerId;
-    private String customerNickName;
 }

--- a/src/main/java/com/zerobase/everycampingbackend/domain/order/entity/OrderProduct.java
+++ b/src/main/java/com/zerobase/everycampingbackend/domain/order/entity/OrderProduct.java
@@ -47,7 +47,11 @@ public class OrderProduct extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private OrderStatus status;
 
-    private Integer amount;
+    private Integer amount; //총액
+
+    private String productNameSnapshot; // 주문 시 상품명
+    private Integer stockPriceSnapshot; // 주문 시 개당 가격
+    private String imageUriSnapshot; // 주문 시 이미지
 
     public static OrderProduct of(Orders orders, Product product, Integer quantity) {
 
@@ -57,6 +61,9 @@ public class OrderProduct extends BaseEntity {
             .status(OrderStatus.COMPLETE)
             .quantity(quantity)
             .amount(quantity * product.getPrice())
+            .productNameSnapshot(product.getName())
+            .stockPriceSnapshot(product.getPrice())
+            .imageUriSnapshot(product.getImageUri())
             .build();
     }
 }

--- a/src/main/java/com/zerobase/everycampingbackend/domain/order/entity/Orders.java
+++ b/src/main/java/com/zerobase/everycampingbackend/domain/order/entity/Orders.java
@@ -31,5 +31,7 @@ public class Orders extends BaseEntity {
     @JoinColumn(name = "customer_id")
     private Customer customer;
 
-
+    private String address;
+    private String phone;
+    
 }

--- a/src/main/java/com/zerobase/everycampingbackend/domain/order/form/OrderForm.java
+++ b/src/main/java/com/zerobase/everycampingbackend/domain/order/form/OrderForm.java
@@ -14,6 +14,11 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class OrderForm {
 
+    @NotNull
+    private String address;
+    @NotNull
+    private String phone;
+
     private List<OrderProductForm> orderProductFormList;
 
     @Getter

--- a/src/main/java/com/zerobase/everycampingbackend/domain/order/repository/OrderProductRepositoryImpl.java
+++ b/src/main/java/com/zerobase/everycampingbackend/domain/order/repository/OrderProductRepositoryImpl.java
@@ -46,6 +46,8 @@ public class OrderProductRepositoryImpl implements OrderProductRepositoryCustom 
 
         List<OrderProductByCustomerDto> list = queryFactory
             .select(Projections.fields(OrderProductByCustomerDto.class,
+                orders.address,
+                orders.phone,
                 orderProduct.product.id.as("productId"),
                 orderProduct.productNameSnapshot,
                 orderProduct.stockPriceSnapshot,

--- a/src/main/java/com/zerobase/everycampingbackend/domain/order/repository/OrderProductRepositoryImpl.java
+++ b/src/main/java/com/zerobase/everycampingbackend/domain/order/repository/OrderProductRepositoryImpl.java
@@ -61,7 +61,7 @@ public class OrderProductRepositoryImpl implements OrderProductRepositoryCustom 
 
             .where(
                 orders.customer.id.eq(customerId),
-                likeProductName(form.getProductName()),
+                likeProductNameSnapShot(form.getProductName()),
                 goe(form.getStartDate()),
                 loe(form.getEndDate())
             )
@@ -183,6 +183,14 @@ public class OrderProductRepositoryImpl implements OrderProductRepositoryCustom 
         }
 
         return product.name.like("%" + name + "%");
+    }
+
+    private BooleanExpression likeProductNameSnapShot(String name) {
+        if (StringUtils.isNullOrEmpty(name)) {
+            return null;
+        }
+
+        return orderProduct.productNameSnapshot.like("%" + name + "%");
     }
 
     private BooleanExpression goe(Date startDate) {

--- a/src/main/java/com/zerobase/everycampingbackend/domain/order/service/OrderService.java
+++ b/src/main/java/com/zerobase/everycampingbackend/domain/order/service/OrderService.java
@@ -36,6 +36,8 @@ public class OrderService {
 
         Orders orders = ordersRepository.save(Orders.builder()
             .customer(customer)
+            .address(form.getAddress())
+            .phone(form.getPhone())
             .build());
 
         form.getOrderProductFormList().forEach(f -> orderProduct(orders, f));

--- a/src/main/java/com/zerobase/everycampingbackend/domain/order/service/OrderService.java
+++ b/src/main/java/com/zerobase/everycampingbackend/domain/order/service/OrderService.java
@@ -76,15 +76,11 @@ public class OrderService {
             .orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUNT));
 
         if(!orderProduct.getOrders().getCustomer().getId().equals(customer.getId())) {
-            throw new CustomException(ErrorCode.NOT_AUTHORISED);
+            throw new CustomException(ErrorCode.ORDER_CHANGE_STATUS_NOT_AUTHORISED);
         }
 
-        if(orderProduct.getStatus().equals(OrderStatus.CONFIRM)) {
-            throw new CustomException(ErrorCode.ORDER_ALREADY_CONFIRMED);
-        }
-
-        if(orderProduct.getStatus().equals(OrderStatus.CANCEL)) {
-            throw new CustomException(ErrorCode.ORDER_ALREADY_CANCELED);
+        if(!orderProduct.getStatus().equals(OrderStatus.COMPLETE)) {
+            throw new CustomException(ErrorCode.ORDER_ALREADY_CONFIRMED_OR_CANCELED);
         }
 
         orderProduct.setStatus(OrderStatus.CONFIRM);
@@ -97,15 +93,11 @@ public class OrderService {
             .orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUNT));
 
         if(!orderProduct.getOrders().getCustomer().getId().equals(customer.getId())) {
-            throw new CustomException(ErrorCode.NOT_AUTHORISED);
+            throw new CustomException(ErrorCode.ORDER_CHANGE_STATUS_NOT_AUTHORISED);
         }
 
-        if(orderProduct.getStatus().equals(OrderStatus.CONFIRM)) {
-            throw new CustomException(ErrorCode.ORDER_ALREADY_CONFIRMED);
-        }
-
-        if(orderProduct.getStatus().equals(OrderStatus.CANCEL)) {
-            throw new CustomException(ErrorCode.ORDER_ALREADY_CANCELED);
+        if(!orderProduct.getStatus().equals(OrderStatus.COMPLETE)) {
+            throw new CustomException(ErrorCode.ORDER_ALREADY_CONFIRMED_OR_CANCELED);
         }
 
         orderProduct.getProduct().setStock(

--- a/src/main/java/com/zerobase/everycampingbackend/exception/ErrorCode.java
+++ b/src/main/java/com/zerobase/everycampingbackend/exception/ErrorCode.java
@@ -16,8 +16,8 @@ public enum ErrorCode {
   CART_PRODUCT_ALREADY_ADDED(HttpStatus.BAD_REQUEST, "이미 장바구니에 등록된 상품입니다."),
 
   ORDER_NOT_FOUNT(HttpStatus.NOT_FOUND, "존재하지 않는 주문입니다."),
-  ORDER_ALREADY_CONFIRMED(HttpStatus.BAD_REQUEST, "이미 구매확정된 주문입니다."),
-  ORDER_ALREADY_CANCELED(HttpStatus.BAD_REQUEST, "이미 취소된 주문입니다."),
+  ORDER_ALREADY_CONFIRMED_OR_CANCELED(HttpStatus.BAD_REQUEST, "이미 확정/취소된 주문입니다."),
+  ORDER_CHANGE_STATUS_NOT_AUTHORISED(HttpStatus.UNAUTHORIZED, "확정/취소 권한이 없습니다."),
 
 
   LOGIN_CHECK_FAIL(HttpStatus.BAD_REQUEST, "일치하는 정보가 없습니다."),
@@ -38,7 +38,7 @@ public enum ErrorCode {
   TOKEN_STILL_ALIVE(HttpStatus.BAD_REQUEST, "재발급 대상 토큰이 아닙니다."),
   TOKEN_NOT_ALIVE(HttpStatus.BAD_REQUEST, "재발급 대상 토큰입니다."),
 
-  NOT_AUTHORISED(HttpStatus.UNAUTHORIZED, "권한이 없습니다."),
+
 
   AUTH_CODE_NOT_VALID(HttpStatus.UNAUTHORIZED, "유효하지 않은 인증코드입니다."),
 

--- a/src/main/java/com/zerobase/everycampingbackend/web/controller/OrderController.java
+++ b/src/main/java/com/zerobase/everycampingbackend/web/controller/OrderController.java
@@ -14,6 +14,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -44,7 +46,7 @@ public class OrderController {
     public ResponseEntity<Page<OrderProductByCustomerDto>> getOrdersByCustomer(
         @AuthenticationPrincipal Customer customer,
         @ModelAttribute SearchOrderByCustomerForm form,
-        Pageable pageable) {
+        @PageableDefault(sort="createdAt", direction = Direction.DESC) Pageable pageable) {
 
         return ResponseEntity.ok(orderService.getOrdersByCustomer(form, customer.getId(), pageable));
     }

--- a/src/main/java/com/zerobase/everycampingbackend/web/controller/OrderController.java
+++ b/src/main/java/com/zerobase/everycampingbackend/web/controller/OrderController.java
@@ -55,7 +55,7 @@ public class OrderController {
     public ResponseEntity<Page<OrderProductBySellerDto>> getOrdersBySeller(
         @AuthenticationPrincipal Seller seller,
         @ModelAttribute SearchOrderBySellerForm form,
-        Pageable pageable) {
+        @PageableDefault(sort="createdAt", direction = Direction.DESC) Pageable pageable) {
 
         return ResponseEntity.ok(orderService.getOrdersBySeller(form, seller.getId(), pageable));
     }

--- a/src/main/java/com/zerobase/everycampingbackend/web/controller/OrderController.java
+++ b/src/main/java/com/zerobase/everycampingbackend/web/controller/OrderController.java
@@ -11,6 +11,7 @@ import com.zerobase.everycampingbackend.domain.user.entity.Seller;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
@@ -27,6 +28,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/orders")
 @RequiredArgsConstructor
+@Slf4j
 public class OrderController {
 
     private final OrderService orderService;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,7 +7,8 @@ spring.config.import=myDatabaseInfo.properties
 #spring.datasource.password=
 
 #jpa
-spring.jpa.show-sql = true
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true
 
 #redis
 spring.redis.host=localhost


### PR DESCRIPTION
Background
---
주문 조회를 리뉴얼하여 join 횟수를 낮추고 성능을 올렸습니다.
또 비지니스적 요구사항으로, 주문 시에 배송지주소와 수령인 전화번호를 입력받도록 수정하였고, 주문 시에는 주문 시점 상품의 snapshot이 저장되도록 변경하였습니다.

Change
---
1. 주문 시 배송지주소, 수령자 전화번호 입력 받도록 수정했습니다.
2. 고객/판매자 주문 조회(검색) 시, request와 response가 변경되었습니다. 자세한 정보는 API 명세를 참고해주시면 감사하겠습니다.
3. 고객/판매자 주문 조회(검색) 시 sorting이 구현되었습니다. 기본 정렬 기준은 `주문일자` 최신순이며 `주문금액`, `주문상태`, `주문일자` 기준으로 오름차순, 내림차순 정렬할 수 있습니다. 여러 기준으로 정렬도 가능합니다. 자세한 내용은 역시 API 명세서를 참고해 주세요.
4. 주문취소/구매확정 시 예외처리 로직을 수정하여 안정성을 올렸습니다.

Test
---
포스트맨을 통한 실 테스트 확인

Analatics
---
기술 포트폴리오인데 지나치게 비지니스적인 요소를 신경쓴게 아닌가 하는 고민이 조금 듭니다..

Discuss
---
queryDsl을 사용할 때 pageable에서 제공해주는 sort와 동일한 기능을 하는 정렬을 구현하기 위해 Common 패키지에 QueryDslUtil 클래스를 만들었습니다. 만약 queryDsl 을 사용하면서 정렬을 해야 한다면 참고하시면 좋을 것 같습니다.