### PR TITLE
Fix websocket auth error

### DIFF
--- a/src/main/java/com/zerobase/everycampingbackend/config/SecurityConfiguration.java
+++ b/src/main/java/com/zerobase/everycampingbackend/config/SecurityConfiguration.java
@@ -35,6 +35,8 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
         , "/sellers/signin"
         , "/sellers/signup"
         , "/sellers/reissue"
+        , "/websocket/**"
+        , "/questions"
 
         //테스트
         , "/test/**"

--- a/src/main/java/com/zerobase/everycampingbackend/domain/auth/filter/JwtAuthFilter.java
+++ b/src/main/java/com/zerobase/everycampingbackend/domain/auth/filter/JwtAuthFilter.java
@@ -25,6 +25,13 @@ public class JwtAuthFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
         FilterChain filterChain) throws ServletException, IOException {
 
+        System.out.println(request.getRequestURL().toString());
+        boolean isWebSocketHandShakingRequest = request.getRequestURL().toString().contains("websocket");
+        if (isWebSocketHandShakingRequest) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
         String token = resolveTokenFromRequest(request);
 
         if(StringUtils.hasText(token) && jwtAuthenticationProvider.validateToken(token)){

--- a/src/main/java/com/zerobase/everycampingbackend/domain/question/service/QuestionService.java
+++ b/src/main/java/com/zerobase/everycampingbackend/domain/question/service/QuestionService.java
@@ -3,6 +3,7 @@ package com.zerobase.everycampingbackend.domain.question.service;
 import com.zerobase.everycampingbackend.domain.question.entity.Message;
 import com.zerobase.everycampingbackend.domain.question.form.MessageForm;
 import com.zerobase.everycampingbackend.domain.question.repository.MessageRepository;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -15,11 +16,11 @@ public class QuestionService {
         messageRepository.save(Message.from(messageForm));
     }
 
-//    public String generateQuestionRoom() {
-//        while (true) {
-//            String questionRoomId = UUID.randomUUID().toString();
-//            if (messageRepository.existsByQuestionRoomId(questionRoomId)) continue;
-//            return questionRoomId;
-//        }
-//    }
+    public String generateQuestionRoom() {
+        while (true) {
+            String questionRoomId = UUID.randomUUID().toString();
+            if (messageRepository.existsByQuestionRoomId(questionRoomId)) continue;
+            return questionRoomId;
+        }
+    }
 }

--- a/src/main/java/com/zerobase/everycampingbackend/web/controller/QuestionController.java
+++ b/src/main/java/com/zerobase/everycampingbackend/web/controller/QuestionController.java
@@ -8,6 +8,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
@@ -20,17 +21,17 @@ public class QuestionController {
     @MessageMapping("/questions/{questionRoomId}")
     @SendTo("/topic/questions/{questionRoomId}")
     public MessageForm questionChat(@DestinationVariable String questionRoomId, MessageForm messageForm) {
-        log.info("Question:: Message from " + questionRoomId + ", content : " + messageForm.getContent());
+        log.info("Question:: Message from " + questionRoomId + ", content : " + messageForm);
         messageForm.setQuestionRoomId(questionRoomId);
         messageForm.setCreatedAt(LocalDateTime.now());
         questionService.addQuestionMessage(messageForm);
         return messageForm;
     }
 
-//    @PostMapping("/questions")
-//    public String createQuestionRoom() {
-//        String id = questionService.generateQuestionRoom();
-//        log.info(id);
-//        return id;
-//    }
+    @PostMapping("/questions")
+    public String createQuestionRoom() {
+        String id = questionService.generateQuestionRoom();
+        log.info(id);
+        return id;
+    }
 }


### PR DESCRIPTION
Background
---
 핸드셰이킹 과정에서 처음으로 보내는 요청 URL은 JWT 필터에 걸려 오류가 발생했습니다. Authorization에 BASIC {dummy value} 같은  패턴으로 값이 들어와있어 발생한 오류입니다. 이걸 해결한 다음엔 핸드셰이킹 중 두 번째 HTTP 요청에서 또 오류가 발생하는데, 이건 URL이 permit 되어 있지 않아 403 오류가 발생했습니다.

Change
---
1. websocket과 관련된 URL을 모두 permit 했습니다. 핸드셰이킹 중 두 번째 요청 URL은 /websocket/{random}/websocket과 같은 형태로 들어와 websocket/** 패턴으로 permit해주도록 하였습니다.
2. JWT Filter에서 websocket 핸드셰이킹과 관련된 URl은 jwt 검사를 생략하도록 하였습니다. RFC 6455에 핸드셰이킹 중에 클라이언트 인증을 하면 안 된다는 규약이 있습니다. 그런데 요청은 HTTP 요청이라 jwt filter를 거쳐가 어쩔 수 없이 검사를 생략하도록 filter를 수정하였습니다. 추후에 jwt 검사를 피하는 다른 방법을 알게 되면 고칠 예정입니다.
3. 
Test
---
리액트로 실행하여 테스트했습니다.

