### PR TITLE
REFACTOR-JWT-STORE

### DIFF
--- a/src/main/java/com/zerobase/everycampingbackend/common/authcode/AuthCodeService.java
+++ b/src/main/java/com/zerobase/everycampingbackend/common/authcode/AuthCodeService.java
@@ -18,14 +18,14 @@ public class AuthCodeService {
 
     public void authCodeRequest(String email) {
         String code = getRandomCode();
-        redisClient.putRefreshToken("AUTHCODE", email, code, 1000 * 60 * 10);
+        redisClient.putValue("AUTHCODE", email, code, 1000 * 60 * 10);
 
         mailClient.sendMail(generateEmailForm(email, code));
     }
 
     public void authCodeRequest(MailForm form) {
         String code = getRandomCode();
-        redisClient.putRefreshToken("AUTHCODE", form.getTo(), code, 1000 * 60 * 10);
+        redisClient.putValue("AUTHCODE", form.getTo(), code, 1000 * 60 * 10);
 
         mailClient.sendMail(form);
     }
@@ -43,9 +43,9 @@ public class AuthCodeService {
     }
 
     public void authCodeVerify(String email, String code) {
-        if(!code.equals(redisClient.getRefreshToken("AUTHCODE", email))){
+        if(!code.equals(redisClient.getValue("AUTHCODE", email))){
             throw new CustomException(ErrorCode.AUTH_CODE_NOT_VALID);
         }
-        redisClient.deleteRefreshToken("AUTHCODE", email);
+        redisClient.deleteValue("AUTHCODE", email);
     }
 }

--- a/src/main/java/com/zerobase/everycampingbackend/domain/redis/RedisClient.java
+++ b/src/main/java/com/zerobase/everycampingbackend/domain/redis/RedisClient.java
@@ -10,16 +10,16 @@ import org.springframework.stereotype.Component;
 public class RedisClient {
     private final RedisTemplate<String, Object> redisTemplate;
 
-    public String getRefreshToken(String index, String key) {
+    public String getValue(String index, String key) {
         return (String) redisTemplate.opsForValue().get(index + ":" + key);
     }
 
-    public void putRefreshToken(String index, String key, String value, long ttl) {
+    public void putValue(String index, String key, String value, long ttl) {
         redisTemplate.opsForValue()
             .set(index + ":" + key, value, ttl, TimeUnit.MILLISECONDS);
     }
 
-    public void deleteRefreshToken(String index, String key) {
+    public void deleteValue(String index, String key) {
         redisTemplate.delete(index + ":" + key);
     }
 }

--- a/src/main/java/com/zerobase/everycampingbackend/domain/user/service/CustomerService.java
+++ b/src/main/java/com/zerobase/everycampingbackend/domain/user/service/CustomerService.java
@@ -1,10 +1,10 @@
 package com.zerobase.everycampingbackend.domain.user.service;
 
-import com.zerobase.everycampingbackend.common.authcode.AuthCodeService;
 import com.zerobase.everycampingbackend.domain.auth.issuer.JwtIssuer;
 import com.zerobase.everycampingbackend.domain.auth.model.JwtDto;
 import com.zerobase.everycampingbackend.domain.auth.model.UserType;
 import com.zerobase.everycampingbackend.domain.auth.service.CustomUserDetailsService;
+import com.zerobase.everycampingbackend.domain.redis.RedisClient;
 import com.zerobase.everycampingbackend.domain.user.entity.Customer;
 import com.zerobase.everycampingbackend.domain.user.form.SignInForm;
 import com.zerobase.everycampingbackend.domain.user.form.SignUpForm;
@@ -12,9 +12,7 @@ import com.zerobase.everycampingbackend.domain.user.repository.CustomerRepositor
 import com.zerobase.everycampingbackend.exception.CustomException;
 import com.zerobase.everycampingbackend.exception.ErrorCode;
 import java.util.Locale;
-import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -24,18 +22,16 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class CustomerService implements CustomUserDetailsService {
 
+    public static final String RT_REDIS_KEY = "RT-CUSTOMER";
     private final CustomerRepository customerRepository;
     private final JwtIssuer jwtIssuer;
     private final PasswordEncoder passwordEncoder;
-    private final RedisTemplate<String, Object> redisTemplate;
-    private final AuthCodeService authCodeService;
+    private final RedisClient redisClient;
 
     public void signUp(SignUpForm form) {
         if (customerRepository.existsByEmail(form.getEmail().toLowerCase(Locale.ROOT))) {
             throw new CustomException(ErrorCode.EMAIL_BEING_USED);
         }
-
-        authCodeService.authCodeRequest(form.getEmail());
 
         customerRepository.save(Customer.from(form, passwordEncoder));
     }
@@ -78,16 +74,15 @@ public class CustomerService implements CustomUserDetailsService {
 
     @Override
     public String getRefreshToken(String email) {
-        return (String) redisTemplate.opsForValue().get("RT-CUSTOMER:" + email);
+        return redisClient.getValue(RT_REDIS_KEY, email);
     }
 
     private void putRefreshToken(String email, String token) {
-        redisTemplate.opsForValue()
-            .set("RT-CUSTOMER:" + email, token, JwtIssuer.EXPIRE_TIME * 2, TimeUnit.MILLISECONDS);
+        redisClient.putValue(RT_REDIS_KEY, email, token, JwtIssuer.EXPIRE_TIME * 2);
     }
 
     private void deleteRefreshToken(String email) {
-        redisTemplate.delete("RT-CUSTOMER:" + email);
+        redisClient.deleteValue(RT_REDIS_KEY, email);
     }
 
 


### PR DESCRIPTION
Background
---
회원 서비스단에서 RedisTemplate을 이용해 Redis를 이용한 CRUD를 하고 있었는데, 재사용성이 좋지 않았다.

Change
---
RedisClient 클래스를 이용해 Redis CRUD에 대한 책임을 분할했다.

Test
---
Postman을 이용한 실 테스트 확인.

Analatics
---
현재 RedisTemplate을 이용한 CRUD를 하고 있는데, Repository를 이용한 접근이 필요할 수도 있다.

Discuss
---