### PR TITLE
Add user update info password

### DIFF
--- a/src/main/java/com/zerobase/everycampingbackend/domain/user/dto/CustomerDto.java
+++ b/src/main/java/com/zerobase/everycampingbackend/domain/user/dto/CustomerDto.java
@@ -1,0 +1,30 @@
+package com.zerobase.everycampingbackend.domain.user.dto;
+
+import com.zerobase.everycampingbackend.domain.user.entity.Customer;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CustomerDto {
+    private String email;
+    private String nickName;
+    private String address;
+    private String zipcode;
+    private String phoneNumber;
+
+    public static CustomerDto from(Customer customer){
+        return CustomerDto.builder()
+            .email(customer.getEmail())
+            .nickName(customer.getNickName())
+            .address(customer.getAddress())
+            .zipcode(customer.getZipcode())
+            .phoneNumber(customer.getPhone())
+            .build();
+    }
+}

--- a/src/main/java/com/zerobase/everycampingbackend/domain/user/dto/SellerDto.java
+++ b/src/main/java/com/zerobase/everycampingbackend/domain/user/dto/SellerDto.java
@@ -1,0 +1,29 @@
+package com.zerobase.everycampingbackend.domain.user.dto;
+
+import com.zerobase.everycampingbackend.domain.user.entity.Seller;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SellerDto {
+    private String email;
+    private String nickName;
+    private String address;
+    private String zipcode;
+    private String phoneNumber;
+
+    public static SellerDto from(Seller seller){
+        return SellerDto.builder()
+            .email(seller.getEmail())
+            .nickName(seller.getNickName())
+            .address(seller.getAddress())
+            .zipcode(seller.getZipcode())
+            .phoneNumber(seller.getPhone())
+            .build();
+    }
+}

--- a/src/main/java/com/zerobase/everycampingbackend/domain/user/form/PasswordForm.java
+++ b/src/main/java/com/zerobase/everycampingbackend/domain/user/form/PasswordForm.java
@@ -1,0 +1,15 @@
+package com.zerobase.everycampingbackend.domain.user.form;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PasswordForm {
+    private String oldPassword;
+    private String newPassword;
+}

--- a/src/main/java/com/zerobase/everycampingbackend/domain/user/form/UserInfoForm.java
+++ b/src/main/java/com/zerobase/everycampingbackend/domain/user/form/UserInfoForm.java
@@ -1,0 +1,19 @@
+package com.zerobase.everycampingbackend.domain.user.form;
+
+import javax.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserInfoForm {
+    @NotBlank
+    private String nickName;
+    private String phoneNumber;
+    private String address;
+    private String zipcode;
+}

--- a/src/main/java/com/zerobase/everycampingbackend/domain/user/service/CustomerService.java
+++ b/src/main/java/com/zerobase/everycampingbackend/domain/user/service/CustomerService.java
@@ -5,9 +5,11 @@ import com.zerobase.everycampingbackend.domain.auth.model.JwtDto;
 import com.zerobase.everycampingbackend.domain.auth.model.UserType;
 import com.zerobase.everycampingbackend.domain.auth.service.CustomUserDetailsService;
 import com.zerobase.everycampingbackend.domain.redis.RedisClient;
+import com.zerobase.everycampingbackend.domain.user.dto.CustomerDto;
 import com.zerobase.everycampingbackend.domain.user.entity.Customer;
 import com.zerobase.everycampingbackend.domain.user.form.SignInForm;
 import com.zerobase.everycampingbackend.domain.user.form.SignUpForm;
+import com.zerobase.everycampingbackend.domain.user.form.UserInfoForm;
 import com.zerobase.everycampingbackend.domain.user.repository.CustomerRepository;
 import com.zerobase.everycampingbackend.exception.CustomException;
 import com.zerobase.everycampingbackend.exception.ErrorCode;
@@ -50,6 +52,18 @@ public class CustomerService implements CustomUserDetailsService {
         deleteRefreshToken(email);
     }
 
+    public void updateInfo(Customer customer, UserInfoForm form) {
+        customer.setNickName(form.getNickName());
+        customer.setPhone(form.getPhoneNumber());
+        customer.setAddress(form.getAddress());
+        customer.setZipcode(form.getZipcode());
+        customerRepository.save(customer);
+    }
+
+    public CustomerDto getInfo(Customer customer){
+        return CustomerDto.from(customer);
+    }
+
     @Override
     public JwtDto issueJwt(String email, Long id) {
         JwtDto jwtDto = jwtIssuer.createToken(email, id, UserType.CUSTOMER.name());
@@ -84,7 +98,4 @@ public class CustomerService implements CustomUserDetailsService {
     private void deleteRefreshToken(String email) {
         redisClient.deleteValue(RT_REDIS_KEY, email);
     }
-
-
-
 }

--- a/src/main/java/com/zerobase/everycampingbackend/domain/user/service/CustomerService.java
+++ b/src/main/java/com/zerobase/everycampingbackend/domain/user/service/CustomerService.java
@@ -7,6 +7,7 @@ import com.zerobase.everycampingbackend.domain.auth.service.CustomUserDetailsSer
 import com.zerobase.everycampingbackend.domain.redis.RedisClient;
 import com.zerobase.everycampingbackend.domain.user.dto.CustomerDto;
 import com.zerobase.everycampingbackend.domain.user.entity.Customer;
+import com.zerobase.everycampingbackend.domain.user.form.PasswordForm;
 import com.zerobase.everycampingbackend.domain.user.form.SignInForm;
 import com.zerobase.everycampingbackend.domain.user.form.SignUpForm;
 import com.zerobase.everycampingbackend.domain.user.form.UserInfoForm;
@@ -62,6 +63,14 @@ public class CustomerService implements CustomUserDetailsService {
 
     public CustomerDto getInfo(Customer customer){
         return CustomerDto.from(customer);
+    }
+
+    public void updatePassword(Customer customer, PasswordForm form) {
+        if(!passwordEncoder.matches(form.getOldPassword(), customer.getPassword())){
+            throw new CustomException(ErrorCode.USER_NOT_AUTHORIZED);
+        }
+        customer.setPassword(passwordEncoder.encode(form.getNewPassword()));
+        customerRepository.save(customer);
     }
 
     @Override

--- a/src/main/java/com/zerobase/everycampingbackend/domain/user/service/SellerService.java
+++ b/src/main/java/com/zerobase/everycampingbackend/domain/user/service/SellerService.java
@@ -7,6 +7,7 @@ import com.zerobase.everycampingbackend.domain.auth.service.CustomUserDetailsSer
 import com.zerobase.everycampingbackend.domain.redis.RedisClient;
 import com.zerobase.everycampingbackend.domain.user.dto.SellerDto;
 import com.zerobase.everycampingbackend.domain.user.entity.Seller;
+import com.zerobase.everycampingbackend.domain.user.form.PasswordForm;
 import com.zerobase.everycampingbackend.domain.user.form.SignInForm;
 import com.zerobase.everycampingbackend.domain.user.form.SignUpForm;
 import com.zerobase.everycampingbackend.domain.user.form.UserInfoForm;
@@ -62,6 +63,14 @@ public class SellerService implements CustomUserDetailsService {
 
     public SellerDto getInfo(Seller seller){
         return SellerDto.from(seller);
+    }
+
+    public void updatePassword(Seller seller, PasswordForm form) {
+        if(!passwordEncoder.matches(form.getOldPassword(), seller.getPassword())){
+            throw new CustomException(ErrorCode.USER_NOT_AUTHORIZED);
+        }
+        seller.setPassword(passwordEncoder.encode(form.getNewPassword()));
+        sellerRepository.save(seller);
     }
 
     @Override

--- a/src/main/java/com/zerobase/everycampingbackend/domain/user/service/SellerService.java
+++ b/src/main/java/com/zerobase/everycampingbackend/domain/user/service/SellerService.java
@@ -5,9 +5,11 @@ import com.zerobase.everycampingbackend.domain.auth.model.JwtDto;
 import com.zerobase.everycampingbackend.domain.auth.model.UserType;
 import com.zerobase.everycampingbackend.domain.auth.service.CustomUserDetailsService;
 import com.zerobase.everycampingbackend.domain.redis.RedisClient;
+import com.zerobase.everycampingbackend.domain.user.dto.SellerDto;
 import com.zerobase.everycampingbackend.domain.user.entity.Seller;
 import com.zerobase.everycampingbackend.domain.user.form.SignInForm;
 import com.zerobase.everycampingbackend.domain.user.form.SignUpForm;
+import com.zerobase.everycampingbackend.domain.user.form.UserInfoForm;
 import com.zerobase.everycampingbackend.domain.user.repository.SellerRepository;
 import com.zerobase.everycampingbackend.exception.CustomException;
 import com.zerobase.everycampingbackend.exception.ErrorCode;
@@ -48,6 +50,18 @@ public class SellerService implements CustomUserDetailsService {
 
     public void signOut(String email) {
         deleteRefreshToken(email);
+    }
+
+    public void updateInfo(Seller seller, UserInfoForm form) {
+        seller.setNickName(form.getNickName());
+        seller.setPhone(form.getPhoneNumber());
+        seller.setAddress(form.getAddress());
+        seller.setZipcode(form.getZipcode());
+        sellerRepository.save(seller);
+    }
+
+    public SellerDto getInfo(Seller seller){
+        return SellerDto.from(seller);
     }
 
     @Override

--- a/src/main/java/com/zerobase/everycampingbackend/exception/ErrorCode.java
+++ b/src/main/java/com/zerobase/everycampingbackend/exception/ErrorCode.java
@@ -23,6 +23,7 @@ public enum ErrorCode {
   LOGIN_CHECK_FAIL(HttpStatus.BAD_REQUEST, "일치하는 정보가 없습니다."),
   USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 회원입니다."),
   EMAIL_BEING_USED(HttpStatus.BAD_REQUEST, "사용중인 이메일입니다."),
+  USER_NOT_AUTHORIZED(HttpStatus.UNAUTHORIZED, "수정 권한이 없습니다."),
 
 
   PRODUCT_NOT_FOUND(HttpStatus.BAD_REQUEST, "상품을 찾을 수 없습니다."),

--- a/src/main/java/com/zerobase/everycampingbackend/web/controller/CustomerController.java
+++ b/src/main/java/com/zerobase/everycampingbackend/web/controller/CustomerController.java
@@ -3,6 +3,8 @@ package com.zerobase.everycampingbackend.web.controller;
 
 import com.zerobase.everycampingbackend.domain.auth.model.JwtDto;
 import com.zerobase.everycampingbackend.domain.auth.service.JwtReissueService;
+import com.zerobase.everycampingbackend.domain.user.dto.CustomerDto;
+import com.zerobase.everycampingbackend.domain.user.form.UserInfoForm;
 import com.zerobase.everycampingbackend.domain.user.service.CustomerService;
 import com.zerobase.everycampingbackend.domain.user.entity.Customer;
 import com.zerobase.everycampingbackend.domain.user.form.SignInForm;
@@ -12,6 +14,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -37,14 +40,26 @@ public class CustomerController {
     }
 
     @GetMapping("/signout")
-    public ResponseEntity<?> customerSignOut(@AuthenticationPrincipal Customer customer){
+    public ResponseEntity<?> customerSignOut(@AuthenticationPrincipal Customer customer) {
         customerService.signOut(customer.getEmail());
         return ResponseEntity.ok().build();
     }
 
     @PostMapping("/reissue")
-    public ResponseEntity<JwtDto> jwtReissue(@RequestBody JwtDto jwtDto){
+    public ResponseEntity<JwtDto> jwtReissue(@RequestBody JwtDto jwtDto) {
         return ResponseEntity.ok(jwtReissueService.reissue(jwtDto));
+    }
+
+    @PutMapping("/info")
+    public ResponseEntity<?> updateInfo(@AuthenticationPrincipal Customer customer,
+        @RequestBody UserInfoForm form) {
+        customerService.updateInfo(customer, form);
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/info")
+    public ResponseEntity<CustomerDto> getInfo(@AuthenticationPrincipal Customer customer){
+        return ResponseEntity.ok(customerService.getInfo(customer));
     }
 
 }

--- a/src/main/java/com/zerobase/everycampingbackend/web/controller/CustomerController.java
+++ b/src/main/java/com/zerobase/everycampingbackend/web/controller/CustomerController.java
@@ -4,6 +4,7 @@ package com.zerobase.everycampingbackend.web.controller;
 import com.zerobase.everycampingbackend.domain.auth.model.JwtDto;
 import com.zerobase.everycampingbackend.domain.auth.service.JwtReissueService;
 import com.zerobase.everycampingbackend.domain.user.dto.CustomerDto;
+import com.zerobase.everycampingbackend.domain.user.form.PasswordForm;
 import com.zerobase.everycampingbackend.domain.user.form.UserInfoForm;
 import com.zerobase.everycampingbackend.domain.user.service.CustomerService;
 import com.zerobase.everycampingbackend.domain.user.entity.Customer;
@@ -13,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -60,6 +62,13 @@ public class CustomerController {
     @GetMapping("/info")
     public ResponseEntity<CustomerDto> getInfo(@AuthenticationPrincipal Customer customer){
         return ResponseEntity.ok(customerService.getInfo(customer));
+    }
+
+    @PatchMapping("/password")
+    public ResponseEntity<?> updatePassword(@AuthenticationPrincipal Customer customer,
+        @RequestBody PasswordForm form){
+        customerService.updatePassword(customer, form);
+        return ResponseEntity.ok().build();
     }
 
 }

--- a/src/main/java/com/zerobase/everycampingbackend/web/controller/SellerController.java
+++ b/src/main/java/com/zerobase/everycampingbackend/web/controller/SellerController.java
@@ -4,6 +4,7 @@ import com.zerobase.everycampingbackend.domain.auth.model.JwtDto;
 import com.zerobase.everycampingbackend.domain.auth.service.JwtReissueService;
 import com.zerobase.everycampingbackend.domain.user.dto.SellerDto;
 import com.zerobase.everycampingbackend.domain.user.entity.Seller;
+import com.zerobase.everycampingbackend.domain.user.form.PasswordForm;
 import com.zerobase.everycampingbackend.domain.user.form.SignInForm;
 import com.zerobase.everycampingbackend.domain.user.form.SignUpForm;
 import com.zerobase.everycampingbackend.domain.user.form.UserInfoForm;
@@ -12,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -58,5 +60,12 @@ public class SellerController {
     @GetMapping("/info")
     public ResponseEntity<SellerDto> getInfo(@AuthenticationPrincipal Seller seller){
         return ResponseEntity.ok(sellerService.getInfo(seller));
+    }
+
+    @PatchMapping("/password")
+    public ResponseEntity<?> updatePassword(@AuthenticationPrincipal Seller seller,
+        @RequestBody PasswordForm form){
+        sellerService.updatePassword(seller, form);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/zerobase/everycampingbackend/web/controller/SellerController.java
+++ b/src/main/java/com/zerobase/everycampingbackend/web/controller/SellerController.java
@@ -2,15 +2,18 @@ package com.zerobase.everycampingbackend.web.controller;
 
 import com.zerobase.everycampingbackend.domain.auth.model.JwtDto;
 import com.zerobase.everycampingbackend.domain.auth.service.JwtReissueService;
+import com.zerobase.everycampingbackend.domain.user.dto.SellerDto;
 import com.zerobase.everycampingbackend.domain.user.entity.Seller;
-import com.zerobase.everycampingbackend.domain.user.service.SellerService;
 import com.zerobase.everycampingbackend.domain.user.form.SignInForm;
 import com.zerobase.everycampingbackend.domain.user.form.SignUpForm;
+import com.zerobase.everycampingbackend.domain.user.form.UserInfoForm;
+import com.zerobase.everycampingbackend.domain.user.service.SellerService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -43,5 +46,17 @@ public class SellerController {
     @PostMapping("/reissue")
     public ResponseEntity<JwtDto> jwtReissue(@RequestBody JwtDto jwtDto){
         return ResponseEntity.ok(jwtReissueService.reissue(jwtDto));
+    }
+
+    @PutMapping("/info")
+    public ResponseEntity<?> updateInfo(@AuthenticationPrincipal Seller seller,
+        @RequestBody UserInfoForm form) {
+        sellerService.updateInfo(seller, form);
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/info")
+    public ResponseEntity<SellerDto> getInfo(@AuthenticationPrincipal Seller seller){
+        return ResponseEntity.ok(sellerService.getInfo(seller));
     }
 }


### PR DESCRIPTION
Background
---
유저 정보의 조회/수정 패스워드 수정 기능이 필요하다.

Change
---
유저 정보의 조회/수정 패스워드 수정 기능 추가.

Test
---
Postman 이용한 테스트 완료.

Analatics
---
유저 정보 수정 부분에 토큰을 이용한 인증 정보를 받기 때문에 따로 검증 로직이 없는데, 이 때문에 문제가 생길 가능성이 있을까?

Discuss
---
