### PR TITLE
Add kakao login

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ out/
 
 ### secret ###
 myDatabaseInfo.properties
+oauth2.properties
 
 ### log ###
 *.log

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt:0.9.1'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.apache.commons:commons-lang3:3.12.0'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
     // queryDSL
     implementation 'com.querydsl:querydsl-jpa:5.0.0'

--- a/src/main/java/com/zerobase/everycampingbackend/config/SecurityConfiguration.java
+++ b/src/main/java/com/zerobase/everycampingbackend/config/SecurityConfiguration.java
@@ -1,7 +1,7 @@
 package com.zerobase.everycampingbackend.config;
 
 import com.zerobase.everycampingbackend.domain.auth.filter.JwtAuthFilter;
-import com.zerobase.everycampingbackend.domain.auth.model.UserType;
+import com.zerobase.everycampingbackend.domain.auth.type.UserType;
 import com.zerobase.everycampingbackend.domain.auth.service.CustomOAuth2UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/com/zerobase/everycampingbackend/domain/auth/dto/CustomOAuth2User.java
+++ b/src/main/java/com/zerobase/everycampingbackend/domain/auth/dto/CustomOAuth2User.java
@@ -1,0 +1,22 @@
+package com.zerobase.everycampingbackend.domain.auth.dto;
+
+import java.util.Collection;
+import java.util.Map;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+
+
+@Getter
+public class CustomOAuth2User extends DefaultOAuth2User {
+
+    private final OAuthAttributes oAuthAttributes;
+
+    public CustomOAuth2User(
+        Collection<? extends GrantedAuthority> authorities,
+        Map<String, Object> attributes, String nameAttributeKey,
+        OAuthAttributes oAuthAttributes) {
+        super(authorities, attributes, nameAttributeKey);
+        this.oAuthAttributes = oAuthAttributes;
+    }
+}

--- a/src/main/java/com/zerobase/everycampingbackend/domain/auth/dto/JwtDto.java
+++ b/src/main/java/com/zerobase/everycampingbackend/domain/auth/dto/JwtDto.java
@@ -1,4 +1,4 @@
-package com.zerobase.everycampingbackend.domain.auth.model;
+package com.zerobase.everycampingbackend.domain.auth.dto;
 
 import javax.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/zerobase/everycampingbackend/domain/auth/dto/OAuthAttributes.java
+++ b/src/main/java/com/zerobase/everycampingbackend/domain/auth/dto/OAuthAttributes.java
@@ -1,0 +1,48 @@
+package com.zerobase.everycampingbackend.domain.auth.dto;
+
+import com.zerobase.everycampingbackend.exception.CustomException;
+import com.zerobase.everycampingbackend.exception.ErrorCode;
+import java.util.Map;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class OAuthAttributes {
+
+    private final Map<String, Object> attributes;
+    private final String nameAttributeKey;
+    private final String name;
+    private final String email;
+
+    @Builder
+    public OAuthAttributes(Map<String, Object> attributes, String nameAttributeKey, String name,
+        String email) {
+        this.attributes = attributes;
+        this.nameAttributeKey = nameAttributeKey;
+        this.name = name;
+        this.email = email;
+    }
+
+    public static OAuthAttributes of(String registrationId, String userNameAttributeName,
+        Map<String, Object> attributes) {
+        if ("kakao".equals(registrationId)) {
+            return ofKakao(userNameAttributeName, attributes);
+        }
+
+        throw new CustomException(ErrorCode.WRONG_OAUTH2_PROVIDER);
+    }
+
+    private static OAuthAttributes ofKakao(String userNameAttributeName,
+        Map<String, Object> attributes) {
+        Map<String, Object> kakaoAccount = (Map<String, Object>)attributes.get("kakao_account");
+        Map<String, Object> kakaoProfile = (Map<String, Object>)kakaoAccount.get("profile");
+
+        return OAuthAttributes.builder()
+            .name((String) kakaoProfile.get("nickname"))
+            .email((String) kakaoAccount.get("email"))
+            .attributes(attributes)
+            .nameAttributeKey(userNameAttributeName)
+            .build();
+    }
+
+}

--- a/src/main/java/com/zerobase/everycampingbackend/domain/auth/dto/UserVo.java
+++ b/src/main/java/com/zerobase/everycampingbackend/domain/auth/dto/UserVo.java
@@ -1,4 +1,4 @@
-package com.zerobase.everycampingbackend.domain.auth.model;
+package com.zerobase.everycampingbackend.domain.auth.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/com/zerobase/everycampingbackend/domain/auth/issuer/JwtIssuer.java
+++ b/src/main/java/com/zerobase/everycampingbackend/domain/auth/issuer/JwtIssuer.java
@@ -1,8 +1,8 @@
 package com.zerobase.everycampingbackend.domain.auth.issuer;
 
 
-import com.zerobase.everycampingbackend.domain.auth.model.JwtDto;
-import com.zerobase.everycampingbackend.domain.auth.model.UserVo;
+import com.zerobase.everycampingbackend.domain.auth.dto.JwtDto;
+import com.zerobase.everycampingbackend.domain.auth.dto.UserVo;
 import com.zerobase.everycampingbackend.domain.auth.util.Aes256Util;
 import com.zerobase.everycampingbackend.exception.CustomException;
 import com.zerobase.everycampingbackend.exception.ErrorCode;

--- a/src/main/java/com/zerobase/everycampingbackend/domain/auth/model/UserType.java
+++ b/src/main/java/com/zerobase/everycampingbackend/domain/auth/model/UserType.java
@@ -1,5 +1,0 @@
-package com.zerobase.everycampingbackend.domain.auth.model;
-
-public enum UserType {
-    CUSTOMER, SELLER, ADMIN
-}

--- a/src/main/java/com/zerobase/everycampingbackend/domain/auth/provider/JwtAuthenticationProvider.java
+++ b/src/main/java/com/zerobase/everycampingbackend/domain/auth/provider/JwtAuthenticationProvider.java
@@ -2,8 +2,8 @@ package com.zerobase.everycampingbackend.domain.auth.provider;
 
 
 import com.zerobase.everycampingbackend.domain.auth.issuer.JwtIssuer;
-import com.zerobase.everycampingbackend.domain.auth.model.JwtDto;
-import com.zerobase.everycampingbackend.domain.auth.model.UserVo;
+import com.zerobase.everycampingbackend.domain.auth.dto.JwtDto;
+import com.zerobase.everycampingbackend.domain.auth.dto.UserVo;
 import com.zerobase.everycampingbackend.domain.auth.service.CustomUserDetailsServiceImpl;
 import com.zerobase.everycampingbackend.exception.CustomException;
 import com.zerobase.everycampingbackend.exception.ErrorCode;

--- a/src/main/java/com/zerobase/everycampingbackend/domain/auth/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/zerobase/everycampingbackend/domain/auth/service/CustomOAuth2UserService.java
@@ -1,0 +1,39 @@
+package com.zerobase.everycampingbackend.domain.auth.service;
+
+import com.zerobase.everycampingbackend.domain.auth.dto.CustomOAuth2User;
+import com.zerobase.everycampingbackend.domain.auth.dto.OAuthAttributes;
+import com.zerobase.everycampingbackend.domain.auth.model.UserType;
+import java.util.Collections;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2UserService<OAuth2UserRequest, OAuth2User> delegate = new DefaultOAuth2UserService();
+        OAuth2User oAuth2User = delegate.loadUser(userRequest);
+
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        String userNameAttributeName = userRequest.getClientRegistration().getProviderDetails()
+            .getUserInfoEndpoint().getUserNameAttributeName();
+
+        OAuthAttributes attributes = OAuthAttributes.of(registrationId, userNameAttributeName, oAuth2User.getAttributes());
+
+
+        return new CustomOAuth2User(
+            Collections.singleton(new SimpleGrantedAuthority("ROLE_" + UserType.CUSTOMER.name())),
+            attributes.getAttributes(),
+            attributes.getNameAttributeKey(),
+            attributes);
+    }
+
+}

--- a/src/main/java/com/zerobase/everycampingbackend/domain/auth/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/zerobase/everycampingbackend/domain/auth/service/CustomOAuth2UserService.java
@@ -2,7 +2,7 @@ package com.zerobase.everycampingbackend.domain.auth.service;
 
 import com.zerobase.everycampingbackend.domain.auth.dto.CustomOAuth2User;
 import com.zerobase.everycampingbackend.domain.auth.dto.OAuthAttributes;
-import com.zerobase.everycampingbackend.domain.auth.model.UserType;
+import com.zerobase.everycampingbackend.domain.auth.type.UserType;
 import java.util.Collections;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;

--- a/src/main/java/com/zerobase/everycampingbackend/domain/auth/service/CustomUserDetailsService.java
+++ b/src/main/java/com/zerobase/everycampingbackend/domain/auth/service/CustomUserDetailsService.java
@@ -1,6 +1,6 @@
 package com.zerobase.everycampingbackend.domain.auth.service;
 
-import com.zerobase.everycampingbackend.domain.auth.model.JwtDto;
+import com.zerobase.everycampingbackend.domain.auth.dto.JwtDto;
 import org.springframework.security.core.userdetails.UserDetailsService;
 
 public interface CustomUserDetailsService extends UserDetailsService {

--- a/src/main/java/com/zerobase/everycampingbackend/domain/auth/service/CustomUserDetailsServiceImpl.java
+++ b/src/main/java/com/zerobase/everycampingbackend/domain/auth/service/CustomUserDetailsServiceImpl.java
@@ -1,8 +1,8 @@
 package com.zerobase.everycampingbackend.domain.auth.service;
 
-import com.zerobase.everycampingbackend.domain.auth.model.JwtDto;
-import com.zerobase.everycampingbackend.domain.auth.model.UserType;
-import com.zerobase.everycampingbackend.domain.auth.model.UserVo;
+import com.zerobase.everycampingbackend.domain.auth.dto.JwtDto;
+import com.zerobase.everycampingbackend.domain.auth.type.UserType;
+import com.zerobase.everycampingbackend.domain.auth.dto.UserVo;
 import com.zerobase.everycampingbackend.domain.user.service.CustomerService;
 import com.zerobase.everycampingbackend.domain.user.service.SellerService;
 import java.util.HashMap;

--- a/src/main/java/com/zerobase/everycampingbackend/domain/auth/service/JwtReissueService.java
+++ b/src/main/java/com/zerobase/everycampingbackend/domain/auth/service/JwtReissueService.java
@@ -1,8 +1,8 @@
 package com.zerobase.everycampingbackend.domain.auth.service;
 
 import com.zerobase.everycampingbackend.domain.auth.issuer.JwtIssuer;
-import com.zerobase.everycampingbackend.domain.auth.model.JwtDto;
-import com.zerobase.everycampingbackend.domain.auth.model.UserVo;
+import com.zerobase.everycampingbackend.domain.auth.dto.JwtDto;
+import com.zerobase.everycampingbackend.domain.auth.dto.UserVo;
 import com.zerobase.everycampingbackend.domain.auth.provider.JwtAuthenticationProvider;
 import com.zerobase.everycampingbackend.exception.CustomException;
 import com.zerobase.everycampingbackend.exception.ErrorCode;

--- a/src/main/java/com/zerobase/everycampingbackend/domain/auth/type/UserType.java
+++ b/src/main/java/com/zerobase/everycampingbackend/domain/auth/type/UserType.java
@@ -1,0 +1,5 @@
+package com.zerobase.everycampingbackend.domain.auth.type;
+
+public enum UserType {
+    CUSTOMER, SELLER, ADMIN
+}

--- a/src/main/java/com/zerobase/everycampingbackend/domain/user/entity/Customer.java
+++ b/src/main/java/com/zerobase/everycampingbackend/domain/user/entity/Customer.java
@@ -6,6 +6,7 @@ import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -33,7 +34,9 @@ public class Customer extends BaseEntity implements UserDetails {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
+  @Column(nullable = false)
   private String email;    // 이메일
+  @Column(nullable = false)
   private String nickName; // 닉네임
   private String password; // 패스워드
   private String address;  // 주소
@@ -48,6 +51,13 @@ public class Customer extends BaseEntity implements UserDetails {
         .password(passwordEncoder.encode(form.getPassword()))
         .nickName(form.getNickName())
         .phone(form.getPhoneNumber())
+        .build();
+  }
+
+  public static Customer of(String email, String nickName) {
+    return Customer.builder()
+        .email(email.toLowerCase(Locale.ROOT))
+        .nickName(nickName)
         .build();
   }
 

--- a/src/main/java/com/zerobase/everycampingbackend/domain/user/service/CustomerService.java
+++ b/src/main/java/com/zerobase/everycampingbackend/domain/user/service/CustomerService.java
@@ -3,8 +3,8 @@ package com.zerobase.everycampingbackend.domain.user.service;
 import static com.zerobase.everycampingbackend.domain.auth.issuer.JwtIssuer.REFRESH_EXPIRE_TIME;
 
 import com.zerobase.everycampingbackend.domain.auth.issuer.JwtIssuer;
-import com.zerobase.everycampingbackend.domain.auth.model.JwtDto;
-import com.zerobase.everycampingbackend.domain.auth.model.UserType;
+import com.zerobase.everycampingbackend.domain.auth.dto.JwtDto;
+import com.zerobase.everycampingbackend.domain.auth.type.UserType;
 import com.zerobase.everycampingbackend.domain.auth.service.CustomUserDetailsService;
 import com.zerobase.everycampingbackend.domain.redis.RedisClient;
 import com.zerobase.everycampingbackend.domain.user.dto.CustomerDto;
@@ -47,6 +47,13 @@ public class CustomerService implements CustomUserDetailsService {
         if (!passwordEncoder.matches(form.getPassword(), customer.getPassword())) {
             throw new CustomException(ErrorCode.LOGIN_CHECK_FAIL);
         }
+
+        return issueJwt(customer.getEmail(), customer.getId());
+    }
+
+    public JwtDto socialSignIn(String email, String nickname) {
+        Customer customer = customerRepository.findByEmail(email)
+            .orElse(customerRepository.save(Customer.of(email, nickname)));
 
         return issueJwt(customer.getEmail(), customer.getId());
     }

--- a/src/main/java/com/zerobase/everycampingbackend/domain/user/service/SellerService.java
+++ b/src/main/java/com/zerobase/everycampingbackend/domain/user/service/SellerService.java
@@ -3,8 +3,8 @@ package com.zerobase.everycampingbackend.domain.user.service;
 import static com.zerobase.everycampingbackend.domain.auth.issuer.JwtIssuer.REFRESH_EXPIRE_TIME;
 
 import com.zerobase.everycampingbackend.domain.auth.issuer.JwtIssuer;
-import com.zerobase.everycampingbackend.domain.auth.model.JwtDto;
-import com.zerobase.everycampingbackend.domain.auth.model.UserType;
+import com.zerobase.everycampingbackend.domain.auth.dto.JwtDto;
+import com.zerobase.everycampingbackend.domain.auth.type.UserType;
 import com.zerobase.everycampingbackend.domain.auth.service.CustomUserDetailsService;
 import com.zerobase.everycampingbackend.domain.redis.RedisClient;
 import com.zerobase.everycampingbackend.domain.user.dto.SellerDto;

--- a/src/main/java/com/zerobase/everycampingbackend/exception/ErrorCode.java
+++ b/src/main/java/com/zerobase/everycampingbackend/exception/ErrorCode.java
@@ -20,20 +20,20 @@ public enum ErrorCode {
   ORDER_CHANGE_STATUS_NOT_AUTHORISED(HttpStatus.UNAUTHORIZED, "확정/취소 권한이 없습니다."),
 
 
-  LOGIN_CHECK_FAIL(HttpStatus.BAD_REQUEST, "일치하는 정보가 없습니다."),
-  USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 회원입니다."),
+  LOGIN_CHECK_FAIL(HttpStatus.NOT_FOUND, "일치하는 정보가 없습니다."),
+  USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."),
   EMAIL_BEING_USED(HttpStatus.BAD_REQUEST, "사용중인 이메일입니다."),
   USER_NOT_AUTHORIZED(HttpStatus.UNAUTHORIZED, "수정 권한이 없습니다."),
 
 
-  PRODUCT_NOT_FOUND(HttpStatus.BAD_REQUEST, "상품을 찾을 수 없습니다."),
-  PRODUCT_SELLER_NOT_MATCHED(HttpStatus.BAD_REQUEST, "상품 수정/삭제 권한이 없습니다."),
+  PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "상품을 찾을 수 없습니다."),
+  PRODUCT_SELLER_NOT_MATCHED(HttpStatus.UNAUTHORIZED, "상품 수정/삭제 권한이 없습니다."),
   PRODUCT_NOT_ENOUGH_STOCK(HttpStatus.BAD_REQUEST, "상품의 재고가 부족합니다."),
   PRODUCT_NOT_ON_SALE(HttpStatus.BAD_REQUEST, "상품이 판매 중이 아닙니다."),
 
-  REVIEW_NOT_FOUND(HttpStatus.BAD_REQUEST, "리뷰를 찾을 수 없습니다."),
+  REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "리뷰를 찾을 수 없습니다."),
   REVIEW_WRITER_NOT_QUALIFIED(HttpStatus.BAD_REQUEST, "리뷰 작성은 해당 상품을 구매한 고객만 가능합니다."),
-  REVIEW_EDITOR_NOT_MATCHED(HttpStatus.BAD_REQUEST, "리뷰 수정/삭제 권한이 없습니다."),
+  REVIEW_EDITOR_NOT_MATCHED(HttpStatus.UNAUTHORIZED, "리뷰 수정/삭제 권한이 없습니다."),
 
   TOKEN_NOT_VALID(HttpStatus.FORBIDDEN, "유효하지 않은 토큰입니다."),
   TOKEN_STILL_ALIVE(HttpStatus.BAD_REQUEST, "재발급 대상 토큰이 아닙니다."),

--- a/src/main/java/com/zerobase/everycampingbackend/exception/ErrorCode.java
+++ b/src/main/java/com/zerobase/everycampingbackend/exception/ErrorCode.java
@@ -43,6 +43,8 @@ public enum ErrorCode {
 
   AUTH_CODE_NOT_VALID(HttpStatus.UNAUTHORIZED, "유효하지 않은 인증코드입니다."),
 
+  WRONG_OAUTH2_PROVIDER(HttpStatus.BAD_REQUEST, "잘못된 소셜로그인 공급자입니다."),
+
   ;
 
 

--- a/src/main/java/com/zerobase/everycampingbackend/web/controller/SellerController.java
+++ b/src/main/java/com/zerobase/everycampingbackend/web/controller/SellerController.java
@@ -1,6 +1,6 @@
 package com.zerobase.everycampingbackend.web.controller;
 
-import com.zerobase.everycampingbackend.domain.auth.model.JwtDto;
+import com.zerobase.everycampingbackend.domain.auth.dto.JwtDto;
 import com.zerobase.everycampingbackend.domain.auth.service.JwtReissueService;
 import com.zerobase.everycampingbackend.domain.user.dto.SellerDto;
 import com.zerobase.everycampingbackend.domain.user.entity.Seller;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,7 +2,7 @@
 spring.datasource.url: jdbc:mariadb://localhost:3306/everycamping
 spring.datasource.driver-class-name=org.mariadb.jdbc.Driver
 
-spring.config.import=myDatabaseInfo.properties
+spring.config.import=myDatabaseInfo.properties, oauth2.properties
 #spring.datasource.username=
 #spring.datasource.password=
 
@@ -28,3 +28,15 @@ spring.mail.properties.mail.smtp.starttls.enable=true
 #deeping LV : 1.ERROR 2.WARN 3.INFO 4.DEBUG. 5.TRACE
 logging.level.com.deeping = WARN
 logging.file.name=log/developer.log
+
+#Social
+spring.security.oauth2.client.registration.kakao.client-name=testapp
+spring.security.oauth2.client.registration.kakao.redirect-uri=http://localhost:8080/login/oauth2/code/kakao
+spring.security.oauth2.client.registration.kakao.client-authentication-method=POST
+spring.security.oauth2.client.registration.kakao.authorization-grant-type=authorization_code
+spring.security.oauth2.client.registration.kakao.scope=profile_nickname, account_email
+
+spring.security.oauth2.client.provider.kakao.authorization-uri = https://kauth.kakao.com/oauth/authorize
+spring.security.oauth2.client.provider.kakao.token-uri = https://kauth.kakao.com/oauth/token
+spring.security.oauth2.client.provider.kakao.user-info-uri = https://kapi.kakao.com/v2/user/me
+spring.security.oauth2.client.provider.kakao.user-name-attribute = id


### PR DESCRIPTION
Background
---
소셜 로그인 중 우선 카카오 로그인을 지원한다.

Change
---
OAuth2-Client를 이용해 카카오 로그인을 구현했다.

Test
---
프론트엔드와 통합 테스트 예정.

Analatics
---
로컬 계정들에 맞춰서 로직을 짜놨는데, 동일 이메일이 있는 경우에 처리가 불안한 감이 있다.

Discuss
---
로컬과 소셜계정에 동일 이메일을 허용 할 것인지, 한다면 DB관리는 어떻게 될 지 등에 대한 토의가 필요합니다.