### PR TITLE
Hotfix intg test 3

### DIFF
--- a/src/main/java/com/zerobase/everycampingbackend/config/SecurityConfiguration.java
+++ b/src/main/java/com/zerobase/everycampingbackend/config/SecurityConfiguration.java
@@ -82,9 +82,11 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
             .logout().logoutSuccessUrl("/")
             .and()
             .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class)
-            .oauth2Login().userInfoEndpoint().userService(customOAuth2UserService)
-            .and()
-            .defaultSuccessUrl("/login/authorized");
+            .oauth2Login(e -> e
+                .userInfoEndpoint().userService(customOAuth2UserService)
+                .and()
+                .defaultSuccessUrl("/login/authorized")
+            );
     }
 
     @Bean

--- a/src/main/java/com/zerobase/everycampingbackend/config/SecurityConfiguration.java
+++ b/src/main/java/com/zerobase/everycampingbackend/config/SecurityConfiguration.java
@@ -90,8 +90,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-
-        configuration.setAllowedOriginPatterns(List.of("*"));
+        configuration.setAllowedOrigins(List.of("http://localhost:5173"));
         configuration.addAllowedMethod("*");
         configuration.addAllowedHeader("*");
         configuration.setAllowCredentials(true);

--- a/src/main/java/com/zerobase/everycampingbackend/domain/product/dto/ProductDetailDto.java
+++ b/src/main/java/com/zerobase/everycampingbackend/domain/product/dto/ProductDetailDto.java
@@ -1,5 +1,6 @@
 package com.zerobase.everycampingbackend.domain.product.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.zerobase.everycampingbackend.domain.product.type.ProductCategory;
 import com.zerobase.everycampingbackend.domain.product.entity.Product;
 import java.time.LocalDateTime;
@@ -30,7 +31,9 @@ public class ProductDetailDto {
     private int reviewCount;
     private double avgScore;
 
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
     private LocalDateTime createdAt;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
     private LocalDateTime modifiedAt;
 
     public static ProductDetailDto from(Product product) {

--- a/src/main/java/com/zerobase/everycampingbackend/domain/product/service/ProductManageService.java
+++ b/src/main/java/com/zerobase/everycampingbackend/domain/product/service/ProductManageService.java
@@ -18,6 +18,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.ObjectUtils;
 import org.springframework.web.multipart.MultipartFile;
 
 @Slf4j
@@ -50,7 +51,16 @@ public class ProductManageService {
         log.info("상품명 (" + form.getName() + ") 수정 시도");
 
         S3Path imagePath = staticImageService.editImage(product.getImagePath(), image);
+        if(ObjectUtils.isEmpty(image)) {
+            imagePath.setImageUri(product.getImageUri());
+            imagePath.setImagePath(product.getImagePath());
+        }
+
         S3Path detailImagePath = staticImageService.editImage(product.getImagePath(), detailImage);
+        if(ObjectUtils.isEmpty(detailImage)){
+            detailImagePath.setImageUri(product.getDetailImageUri());
+            detailImagePath.setImagePath(product.getDetailImagePath());
+        }
 
         product.setOf(form, imagePath, detailImagePath);
 

--- a/src/main/java/com/zerobase/everycampingbackend/domain/review/dto/ReviewDto.java
+++ b/src/main/java/com/zerobase/everycampingbackend/domain/review/dto/ReviewDto.java
@@ -1,5 +1,6 @@
 package com.zerobase.everycampingbackend.domain.review.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.zerobase.everycampingbackend.domain.review.entity.Review;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
@@ -17,7 +18,9 @@ public class ReviewDto {
     private Integer score;
     private String text;
     private String imageUri;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
     private LocalDateTime createdAt;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
     private LocalDateTime modifiedAt;
 
     public static ReviewDto from(Review review){

--- a/src/main/java/com/zerobase/everycampingbackend/domain/review/form/ReviewForm.java
+++ b/src/main/java/com/zerobase/everycampingbackend/domain/review/form/ReviewForm.java
@@ -7,8 +7,10 @@ import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 @AllArgsConstructor
 public class ReviewForm {
     @NotNull

--- a/src/main/java/com/zerobase/everycampingbackend/domain/review/service/ReviewService.java
+++ b/src/main/java/com/zerobase/everycampingbackend/domain/review/service/ReviewService.java
@@ -19,6 +19,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.ObjectUtils;
 import org.springframework.web.multipart.MultipartFile;
 
 @Slf4j
@@ -63,6 +64,10 @@ public class ReviewService {
         }
 
         S3Path s3Path = staticImageService.editImage(review.getImagePath(), image);
+        if(ObjectUtils.isEmpty(image)){
+            s3Path.setImageUri(review.getImageUri());
+            s3Path.setImagePath(review.getImagePath());
+        }
 
         Integer oldScore = review.getScore();
         review.setOf(form, s3Path);

--- a/src/main/java/com/zerobase/everycampingbackend/domain/staticimage/dto/S3Path.java
+++ b/src/main/java/com/zerobase/everycampingbackend/domain/staticimage/dto/S3Path.java
@@ -2,8 +2,10 @@ package com.zerobase.everycampingbackend.domain.staticimage.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.Setter;
 
 @Getter
+@Setter
 @AllArgsConstructor
 public class S3Path {
     private String imageUri;

--- a/src/main/java/com/zerobase/everycampingbackend/domain/user/dto/CustomerDto.java
+++ b/src/main/java/com/zerobase/everycampingbackend/domain/user/dto/CustomerDto.java
@@ -5,13 +5,13 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class CustomerDto {
+    private Long id;
     private String email;
     private String nickName;
     private String address;
@@ -20,6 +20,7 @@ public class CustomerDto {
 
     public static CustomerDto from(Customer customer){
         return CustomerDto.builder()
+            .id(customer.getId())
             .email(customer.getEmail())
             .nickName(customer.getNickName())
             .address(customer.getAddress())

--- a/src/main/java/com/zerobase/everycampingbackend/domain/user/dto/SellerDto.java
+++ b/src/main/java/com/zerobase/everycampingbackend/domain/user/dto/SellerDto.java
@@ -11,6 +11,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 public class SellerDto {
+    private Long id;
     private String email;
     private String nickName;
     private String address;
@@ -19,6 +20,7 @@ public class SellerDto {
 
     public static SellerDto from(Seller seller){
         return SellerDto.builder()
+            .id(seller.getId())
             .email(seller.getEmail())
             .nickName(seller.getNickName())
             .address(seller.getAddress())

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -30,7 +30,9 @@ logging.level.com.deeping = WARN
 logging.file.name=log/developer.log
 
 #Social
-spring.security.oauth2.client.registration.kakao.client-name=testapp
+spring.security.oauth2.client.registration.kakao.client-name=everycamping_local
+#spring.security.oauth2.client.registration.kakao.client-id=
+#spring.security.oauth2.client.registration.kakao.client-secret=
 spring.security.oauth2.client.registration.kakao.redirect-uri=http://localhost:8080/login/oauth2/code/kakao
 spring.security.oauth2.client.registration.kakao.client-authentication-method=POST
 spring.security.oauth2.client.registration.kakao.authorization-grant-type=authorization_code


### PR DESCRIPTION
Background
---
통합테스트2에 생겼던 문제들 수정

Change
---
상품, 리뷰 수정 시 이미지 입력 없을 때의 버그 수정
유저 정보 조회 시 id도 조회 가능하게 추가
LocalDateTime의 출력 포맷 설정
CORS 위해 프론트쪽 호스트 허용 설정 추가
HttpSecurity 설정 구조 변경

Test
---
실 테스트 확인.

Analatics
---
자꾸 나왔었던 302 응답의 원인은 인증이 되지 않았을 때 (토큰 만료 포함) Spring Security에 의해 로그인 페이지로 자동 리디렉트 되기 때문인 것으로 보인다. RESTful API이기 때문에 서버측에서 로그인 페이지를 렌더링 하거나 리디렉션을 할 필요가 없다. 해당 설정을 해제하는 방법을 찾아야 한다.

Discuss
---
CORS 관련 에러는 Axios(Ajax)를 사용해 비동기 통신을 하면 브라우저에서 제공하는 XMLHttpRequest 함수를 호출하게 되는데, 이 때문에 SOP에 위배되어 발생하는 것으로 보입니다. 이 문제를 해결하려면 서버 측에서 해당 출처에 대한 허용을 하거나, 비동기 방식이 아닌 <a> 링크를 이용해 접근하면 된다고 합니다. 해당 문제에 관해 저도 공부를 하겠지만, 함께 찾으면 시간이 단축될 것 같습니다.