### PR TITLE
주문 리팩토링 및 카테고리 조회 구현

### DIFF
--- a/src/main/java/com/zerobase/everycampingbackend/domain/cart/repository/CartRepository.java
+++ b/src/main/java/com/zerobase/everycampingbackend/domain/cart/repository/CartRepository.java
@@ -1,6 +1,7 @@
 package com.zerobase.everycampingbackend.domain.cart.repository;
 
 import com.zerobase.everycampingbackend.domain.cart.entity.CartProduct;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -14,6 +15,6 @@ public interface CartRepository extends JpaRepository<CartProduct, Long> {
 
     @EntityGraph(attributePaths = {"product"}, type = EntityGraphType.LOAD)
     Page<CartProduct> findAllByCustomerId(Long customerId, Pageable pageable);
-
+    List<CartProduct> findAllByCustomerId(Long customerId);
     Optional<CartProduct> findByCustomerIdAndProductId(Long customerId, Long productId);
 }

--- a/src/main/java/com/zerobase/everycampingbackend/domain/order/entity/OrderProduct.java
+++ b/src/main/java/com/zerobase/everycampingbackend/domain/order/entity/OrderProduct.java
@@ -3,6 +3,7 @@ package com.zerobase.everycampingbackend.domain.order.entity;
 import com.zerobase.everycampingbackend.common.BaseEntity;
 import com.zerobase.everycampingbackend.domain.order.type.OrderStatus;
 import com.zerobase.everycampingbackend.domain.product.entity.Product;
+import java.time.LocalDateTime;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
@@ -52,6 +53,8 @@ public class OrderProduct extends BaseEntity {
     private String productNameSnapshot; // 주문 시 상품명
     private Integer stockPriceSnapshot; // 주문 시 개당 가격
     private String imageUriSnapshot; // 주문 시 이미지
+
+    private LocalDateTime confirmedAt; // 주문확정 일자
 
     public static OrderProduct of(Orders orders, Product product, Integer quantity) {
 

--- a/src/main/java/com/zerobase/everycampingbackend/domain/order/service/OrderService.java
+++ b/src/main/java/com/zerobase/everycampingbackend/domain/order/service/OrderService.java
@@ -1,5 +1,6 @@
 package com.zerobase.everycampingbackend.domain.order.service;
 
+import com.zerobase.everycampingbackend.domain.cart.service.CartService;
 import com.zerobase.everycampingbackend.domain.order.dto.OrderByCustomerDto;
 import com.zerobase.everycampingbackend.domain.order.dto.OrderDetailByCustomerDto;
 import com.zerobase.everycampingbackend.domain.order.dto.OrderProductBySellerDto;
@@ -21,6 +22,7 @@ import com.zerobase.everycampingbackend.exception.ErrorCode;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZoneId;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -37,6 +39,7 @@ public class OrderService {
     private final ProductService productService;
     private final OrdersRepository ordersRepository;
     private final OrderProductRepository orderProductRepository;
+    private final CartService cartService;
 
 
     @Transactional
@@ -52,7 +55,13 @@ public class OrderService {
             .totalAmount(0)
             .build());
 
-        form.getOrderProductFormList().forEach(f -> orderProduct(orders, f));
+        List<Long> productIdList = new ArrayList<>();
+        form.getOrderProductFormList().forEach(f ->{
+            orderProduct(orders, f);
+            productIdList.add(f.getProductId());
+        });
+
+        cartService.deleteCartProductsIfExist(customer, productIdList);
     }
 
     private void orderProduct(Orders orders, OrderProductForm orderProductForm) {

--- a/src/main/java/com/zerobase/everycampingbackend/domain/order/service/OrderService.java
+++ b/src/main/java/com/zerobase/everycampingbackend/domain/order/service/OrderService.java
@@ -155,6 +155,7 @@ public class OrderService {
         }
 
         orderProduct.setStatus(OrderStatus.CONFIRM);
+        orderProduct.setConfirmedAt(LocalDateTime.now());
     }
 
     @Transactional

--- a/src/main/java/com/zerobase/everycampingbackend/domain/product/service/ProductService.java
+++ b/src/main/java/com/zerobase/everycampingbackend/domain/product/service/ProductService.java
@@ -5,8 +5,12 @@ import com.zerobase.everycampingbackend.domain.product.dto.ProductDto;
 import com.zerobase.everycampingbackend.domain.product.entity.Product;
 import com.zerobase.everycampingbackend.domain.product.form.ProductSearchForm;
 import com.zerobase.everycampingbackend.domain.product.repository.ProductRepository;
+import com.zerobase.everycampingbackend.domain.product.type.ProductCategory;
 import com.zerobase.everycampingbackend.exception.CustomException;
 import com.zerobase.everycampingbackend.exception.ErrorCode;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
@@ -61,6 +65,10 @@ public class ProductService {
         }
 
         productRepository.save(product);
+    }
+    public List<String> getCategories() {
+        return Stream.of(ProductCategory.values()).map(Enum::name)
+            .collect(Collectors.toList());
     }
 
     public Product getProductById(Long productId){

--- a/src/main/java/com/zerobase/everycampingbackend/web/controller/ProductController.java
+++ b/src/main/java/com/zerobase/everycampingbackend/web/controller/ProductController.java
@@ -4,6 +4,7 @@ import com.zerobase.everycampingbackend.domain.product.dto.ProductDetailDto;
 import com.zerobase.everycampingbackend.domain.product.dto.ProductDto;
 import com.zerobase.everycampingbackend.domain.product.form.ProductSearchForm;
 import com.zerobase.everycampingbackend.domain.product.service.ProductService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -29,5 +30,10 @@ public class ProductController {
     @GetMapping("/{productId}")
     public ResponseEntity<ProductDetailDto> getProductDetail(@PathVariable Long productId){
         return ResponseEntity.ok(productService.getProductDetail(productId));
+    }
+
+    @GetMapping("/categories")
+    public ResponseEntity<List<String>> getCategories() {
+        return ResponseEntity.ok(productService.getCategories());
     }
 }

--- a/src/test/java/com/zerobase/everycampingbackend/cart/service/CartServiceTest.java
+++ b/src/test/java/com/zerobase/everycampingbackend/cart/service/CartServiceTest.java
@@ -245,6 +245,7 @@ class CartServiceTest {
     private Customer createCustomer(String email) {
         Customer customer = Customer.builder()
             .email(email)
+            .nickName("nickName")
             .build();
 
         Customer saved = customerRepository.save(customer);

--- a/src/test/java/com/zerobase/everycampingbackend/order/service/OrdersServiceTest.java
+++ b/src/test/java/com/zerobase/everycampingbackend/order/service/OrdersServiceTest.java
@@ -23,6 +23,7 @@ import com.zerobase.everycampingbackend.domain.user.repository.CustomerRepositor
 import com.zerobase.everycampingbackend.domain.user.repository.SellerRepository;
 import com.zerobase.everycampingbackend.exception.CustomException;
 import com.zerobase.everycampingbackend.exception.ErrorCode;
+import java.time.LocalDate;
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
@@ -230,6 +231,7 @@ class OrdersServiceTest {
         OrderProduct result = orderProductRepository.findAll().get(0);
         assertEquals(result.getId(), orderProductId);
         assertEquals(result.getStatus(), OrderStatus.CONFIRM);
+        assertEquals(LocalDate.now(), result.getConfirmedAt().toLocalDate());
     }
 
 
@@ -250,6 +252,7 @@ class OrdersServiceTest {
     private Customer createCustomer(String email) {
         Customer customer = Customer.builder()
             .email(email)
+            .nickName("고객닉네임")
             .build();
 
         return customerRepository.save(customer);


### PR DESCRIPTION
Background
---
1. 고객이 쇼핑몰에서 주문할 때, 장바구니를 통해 주문하고 있다. 따라서 주문이 완료되면 장바구니에서 해당 물품이 삭제되는것이 자연스럽다.
2. 정산 시 주문 확정 일자를 기준으로 정산한다. 따라서 정산 정확도를 위해서 updateAt과 별도로 confirmedAt 컬럼이 필요하다.
3. 이 프로젝트에서는 카테고리 관리를 따로 하지 않고 enum으로 관리하고 있지만, 프론트의 개발 편의를 위해서 카테고리 조회 기능이 필요하다.

Change
---
1. 주문 시, 주문한 물품이 장바구니 안에 있는 물품일 경우, 장바구니에서 삭제되도록 변경
4. 주문 확정 시 주문 확정 일자 별도로 기록하도록 변경
5. 카테고리 조회 기능 구현

Test
---
단위 테스트 완료

Analatics
---
주문으로 인한 장바구니 삭제 시, deleteAllInBatch 메소드를 사용하여 쿼리 성능을 높였다.

Discuss
---
카테고리 조회 서비스에서, 반환값이 너무 간단한 정보라 DTO를 따로 만들지 않고 List<String> 으로 반환하고 있습니다. 간단하더라도dto를 따로 만드는게 좋을 지 의견 주시면 감사하겠습니다.