### PR TITLE
Refactor kakao login 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ oauth2.yml
 ### log ###
 *.log
 *.gz
+
+### docker ###
+Dockerfile

--- a/src/main/java/com/zerobase/everycampingbackend/config/SecurityConfiguration.java
+++ b/src/main/java/com/zerobase/everycampingbackend/config/SecurityConfiguration.java
@@ -2,30 +2,35 @@ package com.zerobase.everycampingbackend.config;
 
 import com.zerobase.everycampingbackend.domain.auth.entrypoint.CustomBasicAuthenticationEntryPoint;
 import com.zerobase.everycampingbackend.domain.auth.filter.JwtAuthFilter;
+import com.zerobase.everycampingbackend.domain.auth.handler.OAuth2SuccessHandler;
 import com.zerobase.everycampingbackend.domain.auth.service.CustomOAuth2UserService;
 import com.zerobase.everycampingbackend.domain.auth.type.UserType;
+import com.zerobase.everycampingbackend.domain.user.service.CustomerService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.authentication.HttpStatusEntryPoint;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @RequiredArgsConstructor
-@EnableWebSecurity
+@EnableWebSecurity(debug = true)
 @Configuration
 public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 
     private final JwtAuthFilter jwtAuthFilter;
     private final CustomOAuth2UserService customOAuth2UserService;
+    private final CustomerService customerService;
 
     private static final String[] AUTH_IGNORELIST = {
         "/swagger-resources/**",
@@ -84,16 +89,19 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
             .antMatchers("/customers/**").hasRole(UserType.CUSTOMER.name())
             .anyRequest().hasAnyRole(UserType.CUSTOMER.name(), UserType.SELLER.name(), UserType.ADMIN.name())
             .and()
-            .logout().logoutSuccessUrl("/")
-            .and()
             .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class)
             .oauth2Login(e -> e
                 .userInfoEndpoint().userService(customOAuth2UserService)
                 .and()
-                .defaultSuccessUrl("/login/authorized")
+                .successHandler(oAuth2SuccessHandler(customerService))
             )
             .exceptionHandling()
-            .authenticationEntryPoint(authenticationEntryPoint());
+            .authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED));
+    }
+
+    @Bean
+    public OAuth2SuccessHandler oAuth2SuccessHandler(CustomerService customerService) {
+        return new OAuth2SuccessHandler(customerService);
     }
 
     @Bean

--- a/src/main/java/com/zerobase/everycampingbackend/config/SecurityConfiguration.java
+++ b/src/main/java/com/zerobase/everycampingbackend/config/SecurityConfiguration.java
@@ -24,7 +24,7 @@ import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @RequiredArgsConstructor
-@EnableWebSecurity(debug = true)
+@EnableWebSecurity
 @Configuration
 public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 

--- a/src/main/java/com/zerobase/everycampingbackend/domain/auth/dto/JwtDto.java
+++ b/src/main/java/com/zerobase/everycampingbackend/domain/auth/dto/JwtDto.java
@@ -1,5 +1,6 @@
 package com.zerobase.everycampingbackend.domain.auth.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import javax.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -12,7 +13,9 @@ import lombok.NoArgsConstructor;
 @Builder
 public class JwtDto {
     @NotBlank
+    @JsonProperty
     private String accessToken;
     @NotBlank
+    @JsonProperty
     private String refreshToken;
 }

--- a/src/main/java/com/zerobase/everycampingbackend/domain/auth/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/zerobase/everycampingbackend/domain/auth/handler/OAuth2SuccessHandler.java
@@ -1,0 +1,42 @@
+package com.zerobase.everycampingbackend.domain.auth.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zerobase.everycampingbackend.domain.auth.dto.CustomOAuth2User;
+import com.zerobase.everycampingbackend.domain.auth.dto.JwtDto;
+import com.zerobase.everycampingbackend.domain.auth.dto.OAuthAttributes;
+import com.zerobase.everycampingbackend.domain.user.service.CustomerService;
+import java.io.IOException;
+import java.io.PrintWriter;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+
+@RequiredArgsConstructor
+public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    private final CustomerService customerService;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+        Authentication authentication) throws IOException {
+        if(!(authentication instanceof OAuth2AuthenticationToken)){
+            return;
+        }
+
+        CustomOAuth2User user = (CustomOAuth2User) authentication.getPrincipal();
+        OAuthAttributes attributes = user.getOAuthAttributes();
+
+        JwtDto jwt = customerService.socialSignIn(attributes.getEmail(), attributes.getName());
+        ResponseEntity<JwtDto> responseEntity = ResponseEntity.ok(jwt);
+
+        PrintWriter writer = response.getWriter();
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.writeValue(writer, responseEntity);
+        writer.flush();
+        writer.close();
+    }
+}

--- a/src/main/java/com/zerobase/everycampingbackend/domain/auth/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/zerobase/everycampingbackend/domain/auth/service/CustomOAuth2UserService.java
@@ -28,7 +28,6 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
 
         OAuthAttributes attributes = OAuthAttributes.of(registrationId, userNameAttributeName, oAuth2User.getAttributes());
 
-
         return new CustomOAuth2User(
             Collections.singleton(new SimpleGrantedAuthority("ROLE_" + UserType.CUSTOMER.name())),
             attributes.getAttributes(),

--- a/src/main/java/com/zerobase/everycampingbackend/domain/user/dto/SellerDto.java
+++ b/src/main/java/com/zerobase/everycampingbackend/domain/user/dto/SellerDto.java
@@ -17,6 +17,7 @@ public class SellerDto {
     private String address;
     private String zipcode;
     private String phoneNumber;
+    private boolean confirmed;
 
     public static SellerDto from(Seller seller){
         return SellerDto.builder()
@@ -26,6 +27,7 @@ public class SellerDto {
             .address(seller.getAddress())
             .zipcode(seller.getZipcode())
             .phoneNumber(seller.getPhone())
+            .confirmed(seller.isConfirmed())
             .build();
     }
 }

--- a/src/main/java/com/zerobase/everycampingbackend/domain/user/service/CustomerService.java
+++ b/src/main/java/com/zerobase/everycampingbackend/domain/user/service/CustomerService.java
@@ -2,10 +2,10 @@ package com.zerobase.everycampingbackend.domain.user.service;
 
 import static com.zerobase.everycampingbackend.domain.auth.issuer.JwtIssuer.REFRESH_EXPIRE_TIME;
 
-import com.zerobase.everycampingbackend.domain.auth.issuer.JwtIssuer;
 import com.zerobase.everycampingbackend.domain.auth.dto.JwtDto;
-import com.zerobase.everycampingbackend.domain.auth.type.UserType;
+import com.zerobase.everycampingbackend.domain.auth.issuer.JwtIssuer;
 import com.zerobase.everycampingbackend.domain.auth.service.CustomUserDetailsService;
+import com.zerobase.everycampingbackend.domain.auth.type.UserType;
 import com.zerobase.everycampingbackend.domain.redis.RedisClient;
 import com.zerobase.everycampingbackend.domain.user.dto.CustomerDto;
 import com.zerobase.everycampingbackend.domain.user.entity.Customer;
@@ -17,6 +17,7 @@ import com.zerobase.everycampingbackend.domain.user.repository.CustomerRepositor
 import com.zerobase.everycampingbackend.exception.CustomException;
 import com.zerobase.everycampingbackend.exception.ErrorCode;
 import java.util.Locale;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -52,11 +53,22 @@ public class CustomerService implements CustomUserDetailsService {
     }
 
     public JwtDto socialSignIn(String email, String nickname) {
-        Customer customer = customerRepository.findByEmail(email)
-            .orElse(customerRepository.save(Customer.of(email, nickname)));
+        Optional<Customer> optionalCustomer = customerRepository.findByEmail(email);
+        Customer customer;
+        customer = optionalCustomer.orElseGet(
+            () -> customerRepository.save(Customer.of(email, nickname)));
 
         return issueJwt(customer.getEmail(), customer.getId());
     }
+
+//    public JwtDto socialSignIn(SocialSignInForm form) {
+//        Optional<Customer> optionalCustomer = customerRepository.findByEmail(form.getEmail());
+//        Customer customer;
+//        customer = optionalCustomer.orElseGet(
+//            () -> customerRepository.save(Customer.of(form.getEmail(), form.getNickName())));
+//
+//        return issueJwt(customer.getEmail(), customer.getId());
+//    }
 
     public void signOut(String email) {
         deleteRefreshToken(email);

--- a/src/main/java/com/zerobase/everycampingbackend/web/controller/CustomerController.java
+++ b/src/main/java/com/zerobase/everycampingbackend/web/controller/CustomerController.java
@@ -1,8 +1,6 @@
 package com.zerobase.everycampingbackend.web.controller;
 
 
-import com.zerobase.everycampingbackend.domain.auth.dto.CustomOAuth2User;
-import com.zerobase.everycampingbackend.domain.auth.dto.OAuthAttributes;
 import com.zerobase.everycampingbackend.domain.auth.dto.JwtDto;
 import com.zerobase.everycampingbackend.domain.auth.service.JwtReissueService;
 import com.zerobase.everycampingbackend.domain.user.dto.CustomerDto;
@@ -29,7 +27,6 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/customers")
 @RequiredArgsConstructor
-
 public class CustomerController {
 
     private final CustomerService customerService;
@@ -52,13 +49,12 @@ public class CustomerController {
         response.sendRedirect("/oauth2/authorization/" + provider);
     }
 
-    @GetMapping("/social/authorized")
-    public ResponseEntity<JwtDto> customerSocialAuthorized(
-        @AuthenticationPrincipal CustomOAuth2User user) {
-        OAuthAttributes attributes = user.getOAuthAttributes();
-        return ResponseEntity.ok(
-            customerService.socialSignIn(attributes.getEmail(), attributes.getName()));
-    }
+//    @PostMapping("/signin/social/{provider}")
+//    public ResponseEntity<JwtDto> customerSocialSignIn(@PathVariable String provider,
+//        @RequestBody SocialSignInForm form) {
+//        return ResponseEntity.ok(
+//            customerService.socialSignIn(form));
+//    }
 
     @GetMapping("/signout")
     public ResponseEntity<?> customerSignOut(@AuthenticationPrincipal Customer customer) {


### PR DESCRIPTION
Background
---
프론트단에서 1번의 인증 요청을 보내면 백에서 모두 처리하고 jwt만 주는 것이 보안상 안정적이다.

Change
---
프론트에서 유저 정보를 보내주던 방식을 Get 메소드를 통한 인증 요청으로 변경했다.

Test
---
실 테스트 완료.

Analatics
---
JwtFilter와 OAuth2Filter에서 던져지는 exception들을 잡는 entrypoint에 대한 처리가 필요하다.

Discuss
---
code까지는 프론트엔드에서 받고 그 후로 백엔드에서 처리한다는 식의 글도 종종 봤습니다. 하지만 그런 방법이 보안상의 약점이라고 말하는 글도 보았습니다. OAuth2-Client에서 어차피 모든 과정을 처리해주기 때문에 code를 받는 것부터 백엔드에서 처리했습니다. 해당 방식이 더 나은가는 불분명합니다.