### PR TITLE
refactor: 코드 전달 시 get -> post 메소드 사용

### DIFF
--- a/src/main/java/com/zerobase/everycampingbackend/domain/auth/form/CodeForm.java
+++ b/src/main/java/com/zerobase/everycampingbackend/domain/auth/form/CodeForm.java
@@ -1,0 +1,12 @@
+package com.zerobase.everycampingbackend.domain.auth.form;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CodeForm {
+    private String code;
+}

--- a/src/main/java/com/zerobase/everycampingbackend/web/controller/CustomerController.java
+++ b/src/main/java/com/zerobase/everycampingbackend/web/controller/CustomerController.java
@@ -2,6 +2,7 @@ package com.zerobase.everycampingbackend.web.controller;
 
 
 import com.zerobase.everycampingbackend.domain.auth.dto.JwtDto;
+import com.zerobase.everycampingbackend.domain.auth.form.CodeForm;
 import com.zerobase.everycampingbackend.domain.auth.service.JwtReissueService;
 import com.zerobase.everycampingbackend.domain.auth.service.OAuth2UserService;
 import com.zerobase.everycampingbackend.domain.user.dto.CustomerDto;
@@ -22,7 +23,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -45,17 +45,10 @@ public class CustomerController {
         return ResponseEntity.ok(customerService.signIn(form));
     }
 
-//    @GetMapping("/signin/social/{provider}")
-//    public void customerSocialSignIn(@PathVariable String provider,
-//        HttpServletResponse response) throws IOException {
-//        response.sendRedirect("/oauth2/authorization/" + provider);
-//
-//    }
-
-    @GetMapping("/signin/social/{provider}")
+    @PostMapping("/signin/social/{provider}")
     public ResponseEntity<JwtDto> customerSocialSignIn(@PathVariable String provider,
-        @RequestParam String code) {
-        SocialSignInForm form = oAuth2UserService.signIn(provider, code);
+        @RequestBody CodeForm codeForm) {
+        SocialSignInForm form = oAuth2UserService.signIn(provider, codeForm.getCode());
         return ResponseEntity.ok(customerService.socialSignIn(form.getEmail(), form.getNickName()));
     }
 

--- a/src/main/resources/oauth2.yml
+++ b/src/main/resources/oauth2.yml
@@ -23,7 +23,7 @@ spring:
         registration:
           kakao:
             client-name: everycamping
-            redirect-uri: http://localhost:5173/kakaoLoginCall
+            redirect-uri: https://everycamping.netlify.app/kakaoLoginCallback
             client-id: be983b429f1e7b89c3832b7738ae7875
             client-secret: qAXDzUbaRBRrb6tLCGRpSLUszxrbE2fK
 


### PR DESCRIPTION
Background
---
카카오 서버에서 토큰 발급 시 프론트->백 요청 시 get 메소드로 접근하면 에러 발생

Change
---
post 방식으로 변경

Test
---
실 테스트 완료

Analatics
---
백->카카오 요청 시에는 동일하게 post 사용 (토큰 발급 시 post써야만 함)

Discuss
---
왜 post로 하면 되는 건지 모르겠습니다.