### PR TITLE
chore: 이미지 요청 엔드포인트 url 변경

### DIFF
--- a/src/main/resources/database.yml
+++ b/src/main/resources/database.yml
@@ -9,7 +9,7 @@ spring:
 aws:
   s3:
     bucketname: everycamping
-    endpointurl: https://everycamping.shop/files
+    endpointurl: https://everycamping.shop
     accesskey: ENC(le4eWEUA0mhIz702w6DaD34OYeyBIHpRRd6NIvUKjSQ=)
     secretkey: ENC(u635qCpiz8mHZu7Go4oLVM7NCcil3uXp0X6kl+pf2+1mUVkekfULpy6+Et8f+sEvJrKhpKGTz2c=)
 


### PR DESCRIPTION
Background
---
이미지 캐싱 서버를 이용하면 이미지 실 저장소인 S3에 이미지 요청 횟수가 줄어든다.
이미지처럼 용량이 큰 데이터일 수록 비용 감소 효과가 크다.
더불어 캐시를 이용하기에 응답 속도도 올라간다.

Change
---
추가 처리를 필요로 하는 불필요한 경로를 삭제

Test
---
실 테스트 완료

Analatics
---


Discuss
---
