### PR TITLE
Add elasticsearch

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ repositories {
 }
 
 dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/src/main/java/com/zerobase/everycampingbackend/config/ElasticSearchConfig.java
+++ b/src/main/java/com/zerobase/everycampingbackend/config/ElasticSearchConfig.java
@@ -1,0 +1,21 @@
+package com.zerobase.everycampingbackend.config;
+
+import org.elasticsearch.client.RestHighLevelClient;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.elasticsearch.client.ClientConfiguration;
+import org.springframework.data.elasticsearch.client.RestClients;
+import org.springframework.data.elasticsearch.config.AbstractElasticsearchConfiguration;
+import org.springframework.data.elasticsearch.repository.config.EnableElasticsearchRepositories;
+
+@Configuration
+@EnableElasticsearchRepositories
+public class ElasticSearchConfig extends AbstractElasticsearchConfiguration {
+
+    @Override
+    public RestHighLevelClient elasticsearchClient() {
+        ClientConfiguration clientConfiguration = ClientConfiguration.builder()
+            .connectedTo("localhost:9200")
+            .build();
+        return RestClients.create(clientConfiguration).rest();
+    }
+}

--- a/src/main/java/com/zerobase/everycampingbackend/domain/product/entity/ProductDocument.java
+++ b/src/main/java/com/zerobase/everycampingbackend/domain/product/entity/ProductDocument.java
@@ -1,0 +1,54 @@
+package com.zerobase.everycampingbackend.domain.product.entity;
+
+import static org.springframework.data.elasticsearch.annotations.DateFormat.date_hour_minute_second_millis;
+import static org.springframework.data.elasticsearch.annotations.DateFormat.epoch_millis;
+
+import com.zerobase.everycampingbackend.domain.product.type.ProductCategory;
+import java.time.LocalDateTime;
+import java.util.List;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+import org.springframework.data.elasticsearch.annotations.Mapping;
+import org.springframework.data.elasticsearch.annotations.Setting;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Document(indexName = "product")
+@Mapping(mappingPath = "elastic/product-mapping.json")
+@Setting(settingPath = "elastic/product-setting.json")
+public class ProductDocument {
+    @Id
+    private Long id;
+    private String name;
+    @Enumerated(EnumType.STRING)
+    private ProductCategory category;
+    private List<String> tags;
+    private int price;
+    private double avgScore;
+    @Field(type = FieldType.Date, format = {date_hour_minute_second_millis, epoch_millis})
+    private LocalDateTime createdAt;
+
+    public static ProductDocument from(Product product){
+        return ProductDocument.builder()
+            .id(product.getId())
+            .name(product.getName())
+            .category(product.getCategory())
+            .tags(product.getTags())
+            .price(product.getPrice())
+            .avgScore(product.getAvgScore())
+            .createdAt(product.getCreatedAt())
+            .build();
+    }
+}

--- a/src/main/java/com/zerobase/everycampingbackend/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/zerobase/everycampingbackend/domain/product/repository/ProductRepository.java
@@ -2,12 +2,18 @@ package com.zerobase.everycampingbackend.domain.product.repository;
 
 import com.zerobase.everycampingbackend.domain.product.entity.Product;
 import com.zerobase.everycampingbackend.domain.user.entity.Seller;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ProductRepository extends JpaRepository<Product, Long>, ProductRepositoryCustom {
     Page<Product> findAllBySeller(Seller seller, Pageable pageable);
+
+    @Query("Select p from Product p where p.id in :ids order by field(p.id, :ids)")
+    List<Product> findAllByIdIn(@Param("ids") List<Long> ids);
 }

--- a/src/main/java/com/zerobase/everycampingbackend/domain/product/repository/ProductSearchQueryRepository.java
+++ b/src/main/java/com/zerobase/everycampingbackend/domain/product/repository/ProductSearchQueryRepository.java
@@ -1,0 +1,49 @@
+package com.zerobase.everycampingbackend.domain.product.repository;
+
+import com.zerobase.everycampingbackend.domain.product.entity.ProductDocument;
+import com.zerobase.everycampingbackend.domain.product.form.ProductSearchForm;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.SearchHits;
+import org.springframework.data.elasticsearch.core.query.Criteria;
+import org.springframework.data.elasticsearch.core.query.CriteriaQuery;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.ObjectUtils;
+import org.springframework.util.StringUtils;
+
+@Repository
+@RequiredArgsConstructor
+public class ProductSearchQueryRepository {
+    private final ElasticsearchOperations operations;
+
+    public List<Long> findByCondition(ProductSearchForm form, Pageable pageable){
+        CriteriaQuery query = generateQuery(form)
+            .setPageable(pageable);
+
+        SearchHits<ProductDocument> search = operations.search(query, ProductDocument.class);
+        return search.getSearchHits().stream()
+            .map(e -> e.getContent().getId())
+            .collect(Collectors.toList());
+    }
+
+    private CriteriaQuery generateQuery(ProductSearchForm form) {
+        CriteriaQuery query = new CriteriaQuery(new Criteria());
+
+        if (!ObjectUtils.isEmpty(form.getCategory())) {
+            query.addCriteria(Criteria.where("category").is(form.getCategory()));
+        }
+
+        if(!ObjectUtils.isEmpty(form.getTags())) {
+            query.addCriteria(Criteria.where("tags").in(form.getTags()));
+        }
+
+        if(StringUtils.hasText(form.getName())) {
+            query.addCriteria(Criteria.where("name").contains(form.getName()));
+        }
+
+        return query;
+    }
+}

--- a/src/main/java/com/zerobase/everycampingbackend/domain/product/repository/ProductSearchRepository.java
+++ b/src/main/java/com/zerobase/everycampingbackend/domain/product/repository/ProductSearchRepository.java
@@ -1,0 +1,8 @@
+package com.zerobase.everycampingbackend.domain.product.repository;
+
+import com.zerobase.everycampingbackend.domain.product.entity.ProductDocument;
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+
+public interface ProductSearchRepository extends ElasticsearchRepository<ProductDocument, Long> {
+
+}

--- a/src/main/java/com/zerobase/everycampingbackend/domain/product/service/ProductManageService.java
+++ b/src/main/java/com/zerobase/everycampingbackend/domain/product/service/ProductManageService.java
@@ -1,5 +1,7 @@
 package com.zerobase.everycampingbackend.domain.product.service;
 
+import com.zerobase.everycampingbackend.domain.product.entity.ProductDocument;
+import com.zerobase.everycampingbackend.domain.product.repository.ProductSearchRepository;
 import com.zerobase.everycampingbackend.exception.CustomException;
 import com.zerobase.everycampingbackend.exception.ErrorCode;
 import com.zerobase.everycampingbackend.domain.staticimage.dto.S3Path;
@@ -30,6 +32,7 @@ public class ProductManageService {
 
     private final ProductRepository productRepository;
     private final StaticImageService staticImageService;
+    private final ProductSearchRepository searchRepository;
 
     @Transactional
     public void addProduct(Seller seller, ProductManageForm form, MultipartFile image,
@@ -41,7 +44,8 @@ public class ProductManageService {
         S3Path imagePath = staticImageService.saveImage(image);
         S3Path detailImagePath = staticImageService.saveImage(detailImage);
 
-        productRepository.save(Product.of(form, seller, imagePath, detailImagePath));
+        Product product = productRepository.save(Product.of(form, seller, imagePath, detailImagePath));
+        searchRepository.save(ProductDocument.from(product));
 
         log.info("상품명 (" + form.getName() + ") 추가 완료");
     }
@@ -70,6 +74,8 @@ public class ProductManageService {
         product.setOf(form, imagePath, detailImagePath);
 
         productRepository.save(product);
+        searchRepository.save(ProductDocument.from(product));
+
 
         log.info("상품명 (" + form.getName() + ") 수정 완료");
     }
@@ -91,6 +97,7 @@ public class ProductManageService {
         staticImageService.deleteImage(product.getDetailImagePath());
 
         productRepository.delete(product);
+        searchRepository.delete(ProductDocument.from(product));
 
         log.info("상품명 (" + product.getName() + ") 삭제 완료");
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -43,6 +43,7 @@ logging:
   level:
     com:
       deeping: WARN
+    org.springframework.data.elasticsearch.client.WIRE: TRACE
   file:
     name: log/developer.log
 

--- a/src/main/resources/elastic/product-mapping.json
+++ b/src/main/resources/elastic/product-mapping.json
@@ -1,0 +1,17 @@
+{
+  "properties" : {
+    "id" : {"type" : "keyword"},
+    "name" : {
+      "type" : "text",
+      "analyzer" : "korean"
+    },
+    "category" : {"type" : "keyword"},
+    "tags" : {"type": "keyword"},
+    "price" : {"type" : "integer"},
+    "avgScore" : {"type" : "double"},
+    "createdAt" : {
+      "type" : "date",
+      "format": "uuuu-MM-dd'T'HH:mm:ss.SSS||epoch_millis"
+    }
+  }
+}

--- a/src/main/resources/elastic/product-setting.json
+++ b/src/main/resources/elastic/product-setting.json
@@ -1,0 +1,9 @@
+{
+  "analysis": {
+    "analyzer": {
+      "korean": {
+        "type": "nori"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Background
---
텍스트 기반 검색 시 응답이 사용성에 불편함이 있을 정도로 늦어 ES를 도입

Change
---
상품 추가/수정 시 RDB 뿐만 아니라 ES에도 추가/수정
검색 시 ES 통해 인덱스 추출. 그 후, 인덱스 기반 조회를 이용해 RDB에서 전체 데이터 추출
Sorting이 적용되어 나온 인덱스 List의 순서를 그대로 반영하기 위해 @Query 사용해 쿼리 커스텀

Test
---
실 테스트 완료.

Analatics
---
하나의 클래스를 Entity와 Document로 동시에 활용 가능하지만 JPARepository와 ElasticsearchRepository가 서로를 구별하지 못해 각종 에러가 발생한다.
이렇게 되면 @Enable~~~Repository 어노테이션을 통해 클래스 하나하나 일일이 관리해줘야 하기 때문에 차라리 애초에 나누어 관리하는 편이 낫다.
더불어 CUD에 약점을 보이는 ES 특성 상 수정이 잦은 데이터는 제외하고, 또 RDB도 인덱스 기반 서치라면 충분히 속도가 빠르기 때문에 클래스를 나누어 검색에 필요한 최소한의 데이터만 저장하는 것이 효율 면에서 좋다고 판단하였다.

Discuss
---
이걸 이제야합니다 아이고